### PR TITLE
feat(processor): add initial steps of processor with analysis module

### DIFF
--- a/analysis/build.gradle.kts
+++ b/analysis/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id("buildlogic.kotlin-library-conventions")
+}
+
+dependencies {
+    compileOnly(libs.kotlin.reflect)
+}

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/context/AnalysisContext.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/context/AnalysisContext.kt
@@ -1,0 +1,35 @@
+package io.github.kingg22.kogot.analysis.context
+
+import io.github.kingg22.kogot.analysis.models.ClassInfo
+
+/**
+ * Abstract interface for analysis context.
+ * This is backend-agnostic - implementations can be KSP, IDE-based, or test mocks.
+ */
+interface AnalysisContext {
+    /**
+     * The backend type identifier (e.g., "ksp", "idea", "test").
+     */
+    val backend: String
+
+    /**
+     * Resolves a class by its qualified name.
+     * Returns null if the class cannot be found.
+     */
+    fun resolveClass(qualifiedName: String): ClassInfo?
+
+    /**
+     * Returns all classes available in the analysis scope.
+     */
+    fun getAllClasses(): List<ClassInfo>
+
+    /**
+     * Checks if a type is a Godot builtin type.
+     */
+    fun isGodotBuiltinType(qualifiedName: String): Boolean
+
+    /**
+     * Checks if a type is a valid exportable type.
+     */
+    fun isValidExportType(qualifiedName: String): Boolean
+}

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/extractors/ClassExtractor.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/extractors/ClassExtractor.kt
@@ -1,0 +1,74 @@
+package io.github.kingg22.kogot.analysis.extractors
+
+import io.github.kingg22.kogot.analysis.models.AnnotationInfo
+import io.github.kingg22.kogot.analysis.models.ClassInfo
+import io.github.kingg22.kogot.analysis.models.FunctionInfo
+import io.github.kingg22.kogot.analysis.models.ParameterInfo
+import io.github.kingg22.kogot.analysis.models.PropertyInfo
+import io.github.kingg22.kogot.analysis.models.TypeInfo
+
+/**
+ * Interface for extracting class information from source code.
+ * Backend-agnostic - implementations can use KSP, PSI, or other parsers.
+ */
+interface ClassExtractor {
+    /**
+     * Extracts class information from a declaration.
+     *
+     * @param declaration The class declaration (KSClassDeclaration, PsiClass, etc.)
+     * @return ClassInfo representing the extracted data
+     */
+    fun extract(declaration: Any): ClassInfo
+}
+
+/**
+ * Interface for extracting function information.
+ */
+interface FunctionExtractor {
+    /**
+     * Extracts function information from a declaration.
+     *
+     * @param declaration The function declaration
+     * @return FunctionInfo representing the extracted data
+     */
+    fun extract(declaration: Any): FunctionInfo
+}
+
+/**
+ * Interface for extracting property information.
+ */
+interface PropertyExtractor {
+    /**
+     * Extracts property information from a declaration.
+     *
+     * @param declaration The property declaration
+     * @return PropertyInfo representing the extracted data
+     */
+    fun extract(declaration: Any): PropertyInfo
+}
+
+/**
+ * Interface for extracting annotation information.
+ */
+interface AnnotationExtractor {
+    /**
+     * Extracts annotations from a declaration.
+     *
+     * @param declaration The annotated declaration
+     * @return List of AnnotationInfo
+     */
+    fun extractAnnotations(declaration: Any): List<AnnotationInfo>
+}
+
+/**
+ * Interface for resolving types.
+ */
+interface TypeExtractor {
+    /**
+     * Extracts type information from a type declaration.
+     *
+     * @param type The type (KSType, PsiType, etc.)
+     * @return TypeInfo representing the extracted data
+     */
+    fun extractType(type: Any): TypeInfo
+}

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/AnnotationInfo.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/AnnotationInfo.kt
@@ -1,0 +1,28 @@
+package io.github.kingg22.kogot.analysis.models
+
+/**
+ * Represents an annotation applied to a declaration.
+ * This is a KSP-agnostic model - no KSAnnotation types.
+ */
+data class AnnotationInfo(
+    val qualifiedName: String,
+    val shortName: String,
+    val arguments: Map<String, Any> = emptyMap(),
+)
+
+/**
+ * Checks if this annotation matches the given qualified name.
+ */
+fun AnnotationInfo.matches(qualifiedName: String): Boolean =
+    qualifiedName == this.qualifiedName || shortName == qualifiedName
+
+/**
+ * Returns true if this annotation has the given argument.
+ */
+fun AnnotationInfo.hasArgument(name: String): Boolean = arguments.containsKey(name)
+
+/**
+ * Returns the argument value or null if not present.
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> AnnotationInfo.getArgument(name: String): T? = arguments[name] as? T

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/ClassInfo.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/ClassInfo.kt
@@ -1,0 +1,45 @@
+package io.github.kingg22.kogot.analysis.models
+
+/**
+ * Represents a class declaration.
+ */
+data class ClassInfo(
+    val qualifiedName: String,
+    val shortName: String,
+    val packageName: String,
+    val supertypes: List<TypeInfo> = emptyList(),
+    val properties: List<PropertyInfo> = emptyList(),
+    val functions: List<FunctionInfo> = emptyList(),
+    val annotations: List<AnnotationInfo> = emptyList(),
+    val modifiers: Set<String> = emptySet(),
+    val filePath: String = "",
+    val lineNumber: Int = 0,
+)
+
+/**
+ * Returns true if this class has @Tool annotation.
+ */
+fun ClassInfo.hasTool(): Boolean =
+    annotations.any { it.shortName == "Tool" || it.matches("io.github.kingg22.godot.api.annotations.Tool") }
+
+/**
+ * Returns the @Tool annotation or null if not present.
+ */
+fun ClassInfo.getToolAnnotation(): AnnotationInfo? =
+    annotations.find { it.shortName == "Tool" || it.matches("io.github.kingg22.godot.api.annotations.Tool") }
+
+/**
+ * Returns all exported properties.
+ */
+fun ClassInfo.getExportedProperties(): List<PropertyInfo> = properties.filter { it.hasExport() }
+
+/**
+ * Returns all RPC functions.
+ */
+fun ClassInfo.getRpcFunctions(): List<FunctionInfo> = functions.filter { it.hasRpc() }
+
+/**
+ * Checks if this class inherits from Node (directly or transitively).
+ */
+fun ClassInfo.inheritsFromNode(): Boolean =
+    supertypes.any { it.qualifiedName == "io.github.kingg22.godot.api.core.Node" }

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/FunctionInfo.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/FunctionInfo.kt
@@ -1,0 +1,36 @@
+package io.github.kingg22.kogot.analysis.models
+
+/**
+ * Represents a function/method of a class.
+ */
+data class FunctionInfo(
+    val name: String,
+    val returnType: TypeInfo?,
+    val parameters: List<ParameterInfo> = emptyList(),
+    val annotations: List<AnnotationInfo> = emptyList(),
+    val modifiers: Set<String> = emptySet(),
+    val isConstructor: Boolean = false,
+)
+
+/**
+ * Returns true if this function has @Rpc annotation.
+ */
+fun FunctionInfo.hasRpc(): Boolean =
+    annotations.any { it.shortName == "Rpc" || it.matches("io.github.kingg22.godot.api.annotations.Rpc") }
+
+/**
+ * Returns the @Rpc annotation or null if not present.
+ */
+fun FunctionInfo.getRpcAnnotation(): AnnotationInfo? =
+    annotations.find { it.shortName == "Rpc" || it.matches("io.github.kingg22.godot.api.annotations.Rpc") }
+
+/**
+ * Checks if this function is a valid RPC target.
+ */
+fun FunctionInfo.isValidRpcTarget(): Boolean {
+    if (!hasRpc()) return false
+    // RPC functions cannot be constructors
+    if (isConstructor) return false
+    // RPC functions cannot have out parameters (we don't track out specifically here, but void return is expected)
+    return returnType != null
+}

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/ParameterInfo.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/ParameterInfo.kt
@@ -1,0 +1,6 @@
+package io.github.kingg22.kogot.analysis.models
+
+/**
+ * Represents a parameter of a function.
+ */
+data class ParameterInfo(val name: String, val type: TypeInfo, val hasDefaultValue: Boolean = false)

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/PropertyInfo.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/PropertyInfo.kt
@@ -1,0 +1,25 @@
+package io.github.kingg22.kogot.analysis.models
+
+/**
+ * Represents a property (field) of a class.
+ */
+data class PropertyInfo(
+    val name: String,
+    val type: TypeInfo,
+    val isMutable: Boolean = true,
+    val hasDefaultValue: Boolean = false,
+    val annotations: List<AnnotationInfo> = emptyList(),
+    val modifiers: Set<String> = emptySet(),
+)
+
+/**
+ * Returns true if this property has @Export annotation.
+ */
+fun PropertyInfo.hasExport(): Boolean =
+    annotations.any { it.shortName == "Export" || it.matches("io.github.kingg22.godot.api.annotations.Export") }
+
+/**
+ * Returns the @Export annotation or null if not present.
+ */
+fun PropertyInfo.getExportAnnotation(): AnnotationInfo? =
+    annotations.find { it.shortName == "Export" || it.matches("io.github.kingg22.godot.api.annotations.Export") }

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/TypeInfo.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/models/TypeInfo.kt
@@ -1,0 +1,36 @@
+package io.github.kingg22.kogot.analysis.models
+
+/**
+ * Represents a resolved type in the analysis.
+ * This is a KSP-agnostic model - uses simple strings instead of KSType.
+ */
+data class TypeInfo(
+    val qualifiedName: String,
+    val shortName: String,
+    val isNullable: Boolean = false,
+    val isPrimitive: Boolean = false,
+    val typeArguments: List<TypeInfo> = emptyList(),
+)
+
+/**
+ * Common Godot primitive type names.
+ */
+object GodotPrimitives {
+    const val INT = "kotlin.Int"
+    const val LONG = "kotlin.Long"
+    const val SHORT = "kotlin.Short"
+    const val BYTE = "kotlin.Byte"
+    const val FLOAT = "kotlin.Float"
+    const val DOUBLE = "kotlin.Double"
+    const val BOOLEAN = "kotlin.Boolean"
+    const val STRING = "kotlin.String"
+
+    val ALL = listOf(INT, LONG, SHORT, BYTE, FLOAT, DOUBLE, BOOLEAN, STRING)
+
+    fun isPrimitive(qualifiedName: String): Boolean = qualifiedName in ALL
+}
+
+/**
+ * Checks if this type is a Godot builtin type (Vector2, Vector3, Color, etc.).
+ */
+fun TypeInfo.isGodotBuiltin(): Boolean = qualifiedName.startsWith("io.github.kingg22.godot.api.builtin.")

--- a/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/resolvers/AnnotationResolver.kt
+++ b/analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/resolvers/AnnotationResolver.kt
@@ -1,0 +1,47 @@
+package io.github.kingg22.kogot.analysis.resolvers
+
+import io.github.kingg22.kogot.analysis.models.AnnotationInfo
+
+/**
+ * Interface for resolving annotations.
+ */
+interface AnnotationResolver {
+    /**
+     * Resolves all annotations on a declaration.
+     *
+     * @param declaration The annotated declaration
+     * @return List of resolved AnnotationInfo
+     */
+    fun resolveAnnotations(declaration: Any): List<AnnotationInfo>
+
+    /**
+     * Checks if a declaration has a specific annotation.
+     *
+     * @param declaration The declaration to check
+     * @param annotationName Fully qualified or short name of the annotation
+     * @return true if the annotation is present
+     */
+    fun hasAnnotation(declaration: Any, annotationName: String): Boolean
+
+    /**
+     * Gets a specific annotation from a declaration.
+     *
+     * @param declaration The declaration
+     * @param annotationName Fully qualified or short name
+     * @return AnnotationInfo or null if not found
+     */
+    fun getAnnotation(declaration: Any, annotationName: String): AnnotationInfo?
+}
+
+/**
+ * Interface for resolving types.
+ */
+interface TypeResolver {
+    /**
+     * Resolves a type from its name string.
+     *
+     * @param typeName The type name (e.g., "Int", "String", "io.github.kingg22.godot.api.builtin.Vector2")
+     * @return Resolved type info or null if unresolved
+     */
+    fun resolve(typeName: String): io.github.kingg22.kogot.analysis.models.TypeInfo?
+}

--- a/docs/design-analysis-processor.md
+++ b/docs/design-analysis-processor.md
@@ -1,0 +1,563 @@
+# Arquitectura KSP Processor para Kogot Bindings
+
+## Context
+
+Necesitamos un KSP processor robusto que:
+1. Extraiga información de anotaciones de los devs (`@Export`, `@Rpc`, `@Tool`, etc.)
+2. Valide el contrato de esas anotaciones
+3. Genere el código de registro para el binding de Godot (Kotlin y/o JSON según flag)
+4. Sea extensible para nuevas reglas y generadores
+5. Tenga un módulo `analysis` propio y reutilizable en IDE plugin
+6. Tenga errores de nivel rustc
+
+---
+
+## Arquitectura de Módulos Gradle
+
+```
+kogot/
+├── analysis/                           # Módulo reusable (KSP-agnostic)
+│   └── src/main/kotlin/io/github/kingg22/kogot/analysis/
+│       ├── models/                     # ClassInfo, FunctionInfo, etc. (sin KS)
+│       ├── extractors/                 # ClassExtractor, FunctionExtractor
+│       ├── resolvers/                  # TypeResolver, AnnotationResolver
+│       └── context/                    # AnalysisContext interface
+│
+├── processor/                          # KSP SymbolProcessor
+│   └── src/main/kotlin/io/github/kingg22/kogot/processor/
+│       ├── KogotProcessor.kt           # Entry point
+│       ├── KogotOptions.kt             # Config (incl. output mode: KT | JSON | BOTH)
+│       ├── diagnostics/               # Rustc-level errors
+│       ├── validation/                # Validators
+│       ├── transformation/            # Enrichers
+│       ├── generation/                # Generators (kt + json)
+│       │   ├── kotlin/                 # KotlinGenerator, BindingGenerator
+│       │   └── json/                   # JsonGenerator
+│       └── bridge/                    # KspAnalysisContext (KSP → Analysis)
+│
+├── processor-test/                     # Tests
+└── codegen/                            # (ya existe)
+```
+
+**Punto clave**: El módulo `analysis` es 100% agnóstico de KSP. Puede reutilizarse en un IDE plugin.
+
+---
+
+## Arquitectura General: Capas + Pipeline de Fases
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     KSP SymbolProcessor                         │
+│                  (io.github.kingg22.kogot.processor)            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │              INFRAESTRUCTURE LAYER                         │ │
+│  │  • KSPContext (KSResolver, KSCodeGenerator, Env)           │ │
+│  │  • DiagnosticReporter (rustc-level)                        │ │
+│  │  • PhaseTimer (timeline por fase)                          │ │
+│  │  • KogotOptions (outputMode: KT | JSON | BOTH)             │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                              ↓                                  │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │              ANALYSIS LAYER (KSP-Agnostic, módulo shared)  │ │
+│  │  • Models: ClassInfo, FunctionInfo, PropertyInfo           │ │
+│  │  • Extractors: ClassExtractor, FunctionExtractor, etc.     │ │
+│  │  • Resolvers: TypeResolver, AnnotationResolver             │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                              ↓                                  │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │              VALIDATION LAYER                              │ │
+│  │  • ValidationContext (shared state)                        │ │
+│  │  • Validators: ExportValidator, RpcValidator, etc.         │ │
+│  │  • ValidationResult (errors/warnings aggregation)          │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                              ↓                                  │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │              TRANSFORMATION LAYER                          │ │
+│  │  • Enrichers: ClassEnricher, FunctionEnricher              │ │
+│  │  • ResolvedModels: EnrichedClass, EnrichedFunction         │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                              ↓                                  │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │              GENERATION LAYER (multi-output)               │ │
+│  │  • Generator interface                                     │ │
+│  │  • KotlinGenerator → .kt binding code                      │ │
+│  │  • JsonGenerator → manifest.json                           │ │
+│  │  • OutputMode decide cual/cuales se ejecutan               │ │
+│  └────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Detalle de Capas
+
+### 1. Infrastructure Layer
+
+```
+processor/src/main/kotlin/io/github/kingg22/kogot/processor/
+├── KogotProcessor.kt              # SymbolProcessor entry point
+├── KogotOptions.kt                 # Configuración (outputMode, etc.)
+├── KogotLogger.kt                  # Wrapper sobre KSPLogger
+├── diagnostics/
+│   ├── DiagnosticContext.kt       # Timeline + errores
+│   ├── DiagnosticReporter.kt      # Interface rustc-level
+│   ├── DiagnosticCode.kt          # KOGOT001, KOGOT002, etc.
+│   ├── DiagnosticLocation.kt      # File, line, column
+│   ├── DiagnosticMessage.kt       # Mensaje + help + note
+│   ├── DiagnosticRenderer.kt      # Adapta a KSP/IDE/text
+│   └── ChronologicalDiagnostics.kt
+└── pipeline/
+    └── ProcessorPipeline.kt       # Orchestrates fases
+```
+
+### 2. Analysis Layer (`analysis/` module, KSP-agnostic)
+
+```
+analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/
+├── models/
+│   ├── ClassInfo.kt              # Modelo limpio de clase
+│   ├── FunctionInfo.kt           # Modelo limpio de función
+│   ├── PropertyInfo.kt           # Modelo limpio de propiedad
+│   ├── ParameterInfo.kt          # Modelo limpio de parámetro
+│   ├── TypeInfo.kt               # Tipo resuelto (sin KS)
+│   └── AnnotationInfo.kt         # Anotación con parámetros
+├── extractors/
+│   ├── KotlinSourceParser.kt     # Parsea fuente Kotlin (sin KSP)
+│   ├── ClassExtractor.kt         # Interface + implementación
+│   ├── FunctionExtractor.kt
+│   ├── PropertyExtractor.kt
+│   └── AnnotationExtractor.kt
+├── resolvers/
+│   ├── TypeResolver.kt           # Resuelve tipos (sin KS)
+│   └── AnnotationResolver.kt    # Extrae anotaciones
+└── context/
+    └── AnalysisContext.kt        # Interface abstracta
+```
+
+**Principio clave**: Los modelos (`ClassInfo`, `FunctionInfo`, etc.) NO contienen tipos de KSP. Solo strings, enums, y estructuras de datos.
+
+### 3. Validation Layer
+
+```
+processor/src/main/kotlin/io/github/kingg22/kogot/processor/validation/
+├── ValidationContext.kt          # Estado compartido entre validators
+├── ValidationResult.kt           # Interface para acumular errores
+├── ValidationResultImpl.kt       # Implementación
+├── Validator.kt                  # Interface base
+├── ValidatorPipeline.kt          # Ejecuta validators en secuencia
+└── validators/
+    ├── ExportValidator.kt        # Valida @Export y variantes
+    ├── RpcValidator.kt           # Valida @Rpc
+    ├── ToolValidator.kt          # Valida @Tool
+    ├── NamingValidator.kt        # Valida convenciones de nombres
+    ├── TypeCompatibilityValidator.kt
+    └── GroupNamingValidator.kt   # Valida @ExportGroup/prefijos
+```
+
+### 4. Transformation Layer
+
+```
+processor/src/main/kotlin/io/github/kingg22/kogot/processor/transformation/
+├── enrichers/
+│   ├── ClassEnricher.kt         # Añade info adicional a ClassInfo
+│   ├── FunctionEnricher.kt
+│   └── PropertyEnricher.kt
+├── models/
+│   ├── EnrichedClass.kt          # ClassInfo + resolved types + hints
+│   ├── EnrichedFunction.kt
+│   └── EnrichedProperty.kt
+└── ResolvedTypeRegistry.kt      # Cache de tipos resueltos
+```
+
+### 5. Generation Layer
+
+```
+processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/
+├── Generator.kt                  # Interface principal
+├── GeneratorContext.kt           # Contexto para generación
+├── kotlin/
+│   ├── KotlinGenerator.kt        # Genera .kt binding code
+│   ├── ClassRegistrationGenerator.kt
+│   ├── PropertyRegistrationGenerator.kt
+│   ├── RpcRegistrationGenerator.kt
+│   └── SignalRegistrationGenerator.kt
+└── json/
+    ├── JsonGenerator.kt          # Genera manifest.json
+    └── JsonSchema.kt             # Schema del JSON output
+```
+
+**Patrón Generator:**
+```kotlin
+interface Generator {
+    val name: String
+    fun generate(context: GeneratorContext, models: List<EnrichedClass>): GeneratedOutput
+}
+
+data class GeneratedOutput(
+    val files: List<GeneratedFile>,
+    val diagnostics: List<DiagnosticMessage>
+)
+
+enum class OutputMode { KOTLIN, JSON, BOTH }
+```
+
+---
+
+## Diagnostic Reporter (Rustc-level DX)
+
+```
+processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/
+├── DiagnosticCode.kt             # KOGOT-001, KOGOT-002, etc.
+├── DiagnosticLocation.kt         # File, line, column
+├── DiagnosticMessage.kt          # main message + help + note
+└── DiagnosticRenderer.kt         # Adapta output a KSP logger / IDE / text
+```
+
+**Formato de error estilo rustc:**
+```
+error[KOGOT-001]: @Export on invalid type
+  --> src/MyNode.kt:15:5
+   |
+15 |     @Export var invalidProp: SomeClass
+   |         ^^^^^^^ Unsupported type 'SomeClass'. Supported: primitives, Godot types.
+   |
+   = help: Use a Godot built-in type or register a custom class
+   = note: This property will not appear in the Inspector
+```
+
+**Componentes:**
+- `DiagnosticCode`: Identificador único (KOGOT001, KOGOT002, etc.)
+- `DiagnosticLocation`: Precisa (file, line, column)
+- `DiagnosticMessage`: Mensaje principal + ayuda secundaria
+- `DiagnosticRenderer`: Adapta el output al target (KSP logger, IDE, text)
+
+---
+
+## Fase Pipeline
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    PROCESSOR PIPELINE                           │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  1. EXTRACTION PHASE                                            │
+│     └─ KSP → Clean Models (via KspAnalysisContext bridge)       │
+│     └─ Extrae anotaciones y metadatos                           │
+│     └─ Detecta símbolos no resueltos (defer)                    │
+│                                                                 │
+│  2. VALIDATION PHASE                                            │
+│     └─ Ejecuta validators en secuencia                          │
+│     └─ Cada validator reporta errores específicos               │
+│     └─ Pipeline continua si hay errores no-fatales              │
+│     └─ Errores fatales detienen el pipeline                     │
+│                                                                 │
+│  3. TRANSFORMATION PHASE                                        │
+│     └─ Resolver tipos faltantes                                 │
+│     └─ Enriquecer modelos con info derivada                     │
+│     └─ Generar EnrichedClass, EnrichedFunction, etc.            │
+│                                                                 │
+│  4. GENERATION PHASE (según OutputMode)                         │
+│     └─ KOTLIN: ejecuta KotlinGenerator                          │
+│     └─ JSON: ejecuta JsonGenerator                              │
+│     └─ BOTH: ejecuta ambos                                      │
+│                                                                 │
+│  5. REPORTING PHASE                                             │
+│     └─ Render diagnostics finales                               │
+│     └─ Devolver símbolos no procesados                          │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Extensibilidad
+
+### Nuevas Anotaciones
+
+1. Crear `AnnotationInfo` en `analysis/models/`
+2. Crear extractor en `analysis/extractors/`
+3. Crear validator en `validation/validators/`
+4. Opcional: crear enricher y generator
+
+### Nuevos Generadores
+
+1. Implementar `Generator` interface
+2. Registrar via SPI: `META-INF/services/GeneratorProvider`
+3. El processor cargará todos los generators automáticamente
+
+### IDE Plugin Support
+
+El módulo `analysis/` es completamente agnóstico de KSP. Para un IDE plugin:
+
+```
+ide-plugin/
+├── analysis/                        # (reused from kogot/analysis module)
+└── ide/
+    ├── IdeaAnalysisContext.kt       # Bridge IDE → Analysis
+    ├── InspectionRegistry.kt
+    └── HighlightRenderer.kt
+```
+
+---
+
+## Testing Strategy
+
+### Sin KSP (Unit Tests)
+
+```kotlin
+// Test de ClassExtractor sin KSP
+@Test
+fun `ClassExtractor extracts class info correctly`() {
+    val extractor = ClassExtractor(annotationResolver)
+    val source = """..."""
+    val classInfo = extractor.extract(parseKotlin(source))
+
+    assertEquals("MyNode", classInfo.name)
+    assertEquals(2, classInfo.properties.size)
+    assertTrue(classInfo.annotations.hasExport())
+}
+```
+
+### Con KSP (Integration Tests)
+
+```kotlin
+@Test
+fun `processor generates binding for @Export annotated class`() {
+    val result = compile(
+        """
+        @Tool
+        class MyNode : Node {
+            @Export var health: Int = 100
+        }
+        """
+    )
+
+    assertThat(result).generatedFile("MyNodeBinding.kt")
+        .contains("registerProperty(\"health\", INT)")
+}
+```
+
+---
+
+## Verification
+
+1. **Unit tests**: Cada extractor, validator, enricher probados aisladamente (sin KSP)
+2. **Integration tests**: KSP processor completo con test fixtures
+3. **Golden tests**: Comparar output generado contra archivos esperados
+4. **Error rendering tests**: Verificar formato de errores en diferentes targets
+
+---
+
+## Archivos Críticos a Crear (orden de implementación sugerido)
+
+| Fase      | Archivo                                                                 | Propósito                  |
+|-----------|-------------------------------------------------------------------------|----------------------------|
+| Analysis  | `analysis/src/main/.../analysis/models/ClassInfo.kt`                    | Modelo limpio de clase     |
+| Analysis  | `analysis/src/main/.../analysis/models/FunctionInfo.kt`                 | Modelo limpio de función   |
+| Analysis  | `analysis/src/main/.../analysis/models/PropertyInfo.kt`                 | Modelo limpio de propiedad |
+| Analysis  | `analysis/src/main/.../analysis/extractors/ClassExtractor.kt`           | Interface + impl           |
+| Analysis  | `analysis/src/main/.../analysis/context/AnalysisContext.kt`             | Interface abstracta        |
+| Processor | `processor/src/main/.../processor/bridge/KspAnalysisContext.kt`         | Bridge KSP → Analysis      |
+| Processor | `processor/src/main/.../processor/diagnostics/DiagnosticCode.kt`        | Identificador único        |
+| Processor | `processor/src/main/.../processor/diagnostics/DiagnosticMessage.kt`     | Mensaje con help/note      |
+| Processor | `processor/src/main/.../processor/diagnostics/DiagnosticRenderer.kt`    | Adapta a target            |
+| Processor | `processor/src/main/.../processor/validation/Validator.kt`              | Interface base             |
+| Processor | `processor/src/main/.../processor/validation/ValidatorPipeline.kt`      | Orchestra validators       |
+| Processor | `processor/src/main/.../processor/generation/Generator.kt`              | Interface principal        |
+| Processor | `processor/src/main/.../processor/generation/kotlin/KotlinGenerator.kt` | Genera .kt                 |
+| Processor | `processor/src/main/.../processor/generation/json/JsonGenerator.kt`     | Genera .json               |
+| Processor | `processor/src/main/.../processor/KogotProcessor.kt`                    | Entry point                |
+| Processor | `processor/src/main/.../processor/KogotOptions.kt`                      | Config + OutputMode        |
+
+---
+
+## Referencias de Patrones
+
+- **ktorgen**: DiagnosticTimer timeline, ValidatorPipeline, DeclarationMapper pattern
+- **utopia**: Task/Rule hierarchy, FileBuilder pattern, Check/Validator pattern
+- **androidx-room**: XProcessing abstraction (KSP-agnostic interfaces), Element stores (caching), sealed type hierarchies, XEquality for proper wrapper equality
+- **Clean Architecture**: Separation of concerns, Dependency Inversion, Single Responsibility
+- **Rustc**: Formato de errores con código, ubicación, ayuda secundaria
+
+---
+
+## Inspiración Adicional: XProcessing de Room
+
+El módulo `room3-compiler-processing/` de androidx Room provee una **abstracción completa sobre KSP** que podemos replicar.
+
+### Patrón Central: Interfaces XProcessing (Backend-Agnostic)
+
+```
+room3-compiler-processing/src/main/java/androidx/room3/compiler/processing/
+├── XProcessingEnv.kt          # Environment interface
+├── XElement.kt               # Base element interface
+├── XType.kt                 # Type interface (sin KSP)
+├── XTypeElement.kt          # Class/interface declarations
+├── XExecutableElement.kt    # Methods/constructors
+├── XFieldElement.kt         # Fields
+├── XAnnotated.kt            # Annotation access
+├── XRoundEnv.kt             # Round information
+├── XBasicAnnotationProcessor.kt  # Processor base
+└── XEquality.kt             # Equality for wrappers
+```
+
+### KSP Implementation (Bridge)
+
+```
+room3-compiler-processing/src/main/java/androidx/room3/compiler/processing/ksp/
+├── KspProcessingEnv.kt      # Implementa XProcessingEnv
+├── KspElement.kt            # Base wrapper para KSAnnotated
+├── KspType.kt               # Base wrapper para KSType
+├── KspTypeElement.kt        # Wrapper para KSClassDeclaration
+├── KspMethodElement.kt      # Wrapper para KSFunctionDeclaration
+├── KspFieldElement.kt       # Wrapper para KSPropertyDeclaration
+└── KspMessager.kt          # Bridge para KSPLogger
+```
+
+### Patrones Clave de Room
+
+**1. Wrapper con Delegation:**
+```kotlin
+internal sealed class KspTypeElement(
+    env: KspProcessingEnv,
+    override val declaration: KSClassDeclaration,
+) : KspElement(env, declaration),
+    XTypeElement,
+    XHasModifiers by KspHasModifiers.create(declaration),
+    XAnnotated by KspAnnotated.create(env, declaration, NO_USE_SITE)
+```
+
+**2. Factory Methods para Type Dispatch:**
+```kotlin
+fun wrap(ksType: KSType, allowPrimitives: Boolean): KspType {
+    return when {
+        ksType.declaration is KSTypeParameter -> KspTypeVariableType(env, ksType)
+        allowPrimitives && ksType.isPrimitiveType() -> KspPrimitiveType(env, ksType)
+        else -> DefaultKspType(env, ksType)
+    }
+}
+```
+
+**3. Caching via Element Stores:**
+```kotlin
+private val typeElementStore = XTypeElementStore(
+    findElement = { resolver.getClassDeclarationByName(it) },
+    wrap = { classDeclaration -> KspTypeElement.create(env, classDeclaration) }
+)
+```
+
+### Aplicación a Nuestro Diseño
+
+Nuestro módulo `analysis/` seguirá el mismo patrón:
+
+```
+analysis/src/main/kotlin/io/github/kingg22/kogot/analysis/
+├── context/
+│   └── AnalysisContext.kt        # Interface (equivalente a XProcessingEnv)
+├── models/
+│   ├── ClassInfo.kt             # Modelo puro (equivalente a XTypeElement simplificado)
+│   ├── FunctionInfo.kt           # Modelo puro
+│   └── ...
+└── extractors/
+    └── KotlinSourceParser.kt     # Parsea fuente (sin KSP)
+```
+
+**En processor/ bridge:**
+```
+processor/src/main/kotlin/.../processor/bridge/
+└── KspAnalysisContext.kt         # Equivalente a KspProcessingEnv de Room
+```
+
+### Test Suite de Room
+
+```
+room3-compiler-processing-testing/
+├── src/main/java/.../util/
+│   ├── Source.kt                  # Crea archivos de test (Java/Kotlin)
+│   └── ProcessorTestExt.kt       # runKspTest(), runProcessorTest()
+└── src/test/java/.../ksp/
+    └── KspTypeTest.kt            # Ejemplo de tests KSP
+```
+
+**Patrón de test:**
+```kotlin
+@Test
+fun typeArguments() {
+    val src = Source.kotlin("foo.kt", """
+        class Subject {
+            val list: List<String?> = TODO()
+        }
+    """.trimIndent())
+    runProcessorTest(listOf(src)) { invocation ->
+        val subject = invocation.processingEnv.requireTypeElement("Subject")
+        subject.getField("list").type.let { type ->
+            assertThat(type.nullability).isEqualTo(NONNULL)
+        }
+    }
+}
+```
+
+---
+
+## Generación de Código con KotlinPoet
+
+KotlinPoet es la librería estándar para generar código Kotlin desde otros programas (equivalente a JavaPoet para Java).
+
+```kotlin
+// Ejemplo simple de KotlinPoet
+val file = FileSpec.builder("com.example", "MyBinding")
+    .addType(TypeSpec.classBuilder("MyBinding")
+        .addFunction(FunSpec.builder("register")
+            .addStatement("println(%S)", "Hello")
+            .build())
+        .build())
+    .build()
+
+file.writeTo(System.out)
+```
+
+**Uso en nuestro diseño:** `KotlinGenerator` usará KotlinPoet para generar el código .kt del binding en lugar de strings concatenados.
+
+### Dependencia Gradle
+
+```kotlin
+// processor/build.gradle.kts
+dependencies {
+    implementation("com.squareup.kotlinpoet:kotlinpoet:1.18.0")
+}
+```
+
+---
+
+## ClassGraph vs KSP (Para Entender Utopia)
+
+### ¿Qué es ClassGraph?
+
+ClassGraph escanea **bytecode compilado** (.class) en lugar de código fuente. Es útil cuando necesitas procesar múltiples lenguajes JVM (Kotlin, Java, Scala, Groovy) porque todos compilan a bytecode.
+
+### Comparación
+
+| Aspecto                | KSP                        | ClassGraph                       |
+|------------------------|----------------------------|----------------------------------|
+| Trabaja sobre          | Código fuente (AST)        | Bytecode compilado               |
+| Soporte multi-lenguaje | Solo Kotlin (+Java básico) | Cualquier lenguaje JVM           |
+| Información de línea   | Exacta                     | Solo del bytecode, no del origen |
+| Incremental            | Sí, integrado              | No, escaneo completo             |
+| Mantenimiento          | Depende de versión Kotlin  | Estable (bytecode no cambia)     |
+
+### ¿Por qué Utopia usa ClassGraph?
+
+Utopia soporta **múltiples lenguajes JVM**: Kotlin, Java, **Scala**, Groovy. KSP solo funciona bien con Kotlin. ClassGraph lee bytecode, y **todo lenguaje JVM compila a bytecode**. Por eso lo eligieron.
+
+### ¿Nos sirve ClassGraph?
+
+**Probablemente no** para el processor principal, porque:
+- Solo procesamos Kotlin
+- Necesitamos línea exacta para errores
+- KSP tiene incremental processing
+
+**Sí nos serviría** si quisiéramos:
+- Un IDE plugin que lea bytecode de dependencias ya compiladas
+- Soportar otros lenguajes en el futuro

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,6 +101,7 @@ download = { id = "de.undercouch.download", version.ref = "undercouch-download" 
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp-plugin" }
 error-prone = { id = "net.ltgt.errorprone", version.ref = "errorprone-gradle" }
 nullaway = { id = "net.ltgt.nullaway", version.ref = "nullaway-gradle" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 # https://mvnrepository.com/artifact/androidx.room/room-compiler-processing-testing
-androidx-room-compiler-testing = "2.8.4"
+androidx-room-compiler = "2.8.4"
 
 # https://github.com/apache/commons-compress/tags
 apache-commons-compress = "1.28.0"
@@ -68,8 +68,9 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 
 # Processor
 ksp-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp-api" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler-processing", version.ref = "androidx-room-compiler" }
 # Processor test
-androidx-room-compiler-testing = { group = "androidx.room", name = "room-compiler-processing-testing", version.ref = "androidx-room-compiler-testing" }
+androidx-room-compiler-testing = { group = "androidx.room", name = "room-compiler-processing-testing", version.ref = "androidx-room-compiler" }
 google-truth = { group = "com.google.truth", name = "truth", version.ref = "google-truth" }
 
 # build-logic

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -1,12 +1,16 @@
 plugins {
-    id("buildlogic.kotlin-application-conventions")
+    id("buildlogic.kotlin-library-conventions")
     id("buildlogic.kotlin-styles-conventions")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 dependencies {
+    implementation(projects.analysis)
     implementation(libs.kotlin.reflect)
     implementation(libs.ksp.api)
     implementation(libs.kotlinpoet.ksp)
+    implementation(libs.androidx.room.compiler)
+    implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.androidx.room.compiler.testing)
     testImplementation(libs.kotlin.test)

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotOptions.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotOptions.kt
@@ -1,0 +1,45 @@
+package io.github.kingg22.kogot.processor
+
+/**
+ * Output mode for the processor.
+ */
+enum class OutputMode {
+    /** Generate Kotlin binding code only (.kt files) */
+    KOTLIN,
+
+    /** Generate JSON manifest only */
+    JSON,
+
+    /** Generate both Kotlin and JSON outputs */
+    BOTH,
+}
+
+/**
+ * Configuration options for the Kogot processor.
+ */
+data class KogotOptions(
+    val outputMode: OutputMode = OutputMode.BOTH,
+    val generatedPackage: String = "io.github.kingg22.godot.generated",
+    val logLevel: LogLevel = LogLevel.WARN,
+) {
+    enum class LogLevel { DEBUG, INFO, WARN, ERROR }
+
+    companion object {
+        const val OUTPUT_MODE_KEY = "kogot.outputMode"
+        const val GENERATED_PACKAGE_KEY = "kogot.generatedPackage"
+        const val LOG_LEVEL_KEY = "kogot.logLevel"
+
+        /**
+         * Parses options from KSP processor options map.
+         */
+        fun fromMap(options: Map<String, String>): KogotOptions = KogotOptions(
+            outputMode = options[OUTPUT_MODE_KEY]?.let {
+                OutputMode.valueOf(it.uppercase())
+            } ?: OutputMode.BOTH,
+            generatedPackage = options[GENERATED_PACKAGE_KEY] ?: "io.github.kingg22.godot.generated",
+            logLevel = options[LOG_LEVEL_KEY]?.let {
+                LogLevel.valueOf(it.uppercase())
+            } ?: LogLevel.WARN,
+        )
+    }
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt
@@ -1,0 +1,187 @@
+package io.github.kingg22.kogot.processor
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import io.github.kingg22.kogot.processor.bridge.toClassInfo
+import io.github.kingg22.kogot.processor.diagnostics.DiagnosticCode
+import io.github.kingg22.kogot.processor.diagnostics.DiagnosticLocation
+import io.github.kingg22.kogot.processor.diagnostics.DiagnosticMessage
+import io.github.kingg22.kogot.processor.diagnostics.DiagnosticRenderer
+import io.github.kingg22.kogot.processor.generation.GeneratedOutput
+import io.github.kingg22.kogot.processor.generation.GeneratorContext
+import io.github.kingg22.kogot.processor.generation.json.JsonGenerator
+import io.github.kingg22.kogot.processor.generation.kotlin.KotlinGenerator
+import io.github.kingg22.kogot.processor.validation.ValidationContext
+import io.github.kingg22.kogot.processor.validation.ValidationResultImpl
+import io.github.kingg22.kogot.processor.validation.ValidatorPipeline
+
+/**
+ * KSP SymbolProcessor for Kogot bindings.
+ */
+class KogotProcessor(environment: SymbolProcessorEnvironment) : SymbolProcessor {
+
+    private val options: KogotOptions = KogotOptions.fromMap(environment.options)
+    private val codeGenerator: CodeGenerator = environment.codeGenerator
+    private val logger: KSPLogger = environment.logger
+
+    override fun process(resolver: Resolver): List<KSClassDeclaration> {
+        val classes = extractClasses(resolver)
+
+        if (classes.isEmpty()) return emptyList()
+
+        // Run validation
+        val validationResult = runValidation(classes)
+
+        // Report validation errors
+        for (error in validationResult.errors) {
+            logger.error(DiagnosticRenderer.renderRustc(error))
+        }
+        for (warning in validationResult.warnings) {
+            logger.warn(DiagnosticRenderer.renderRustc(warning))
+        }
+
+        // Stop if validation failed
+        if (!validationResult.isValid) return emptyList()
+
+        // Generate output
+        val generatedOutput = runGeneration(classes)
+
+        // Report generation diagnostics
+        for (diagnostic in generatedOutput.diagnostics) {
+            when (diagnostic.severity) {
+                ERROR -> logger.error(DiagnosticRenderer.renderRustc(diagnostic))
+                WARNING -> logger.warn(DiagnosticRenderer.renderRustc(diagnostic))
+                INFO -> logger.info(DiagnosticRenderer.renderRustc(diagnostic))
+            }
+        }
+
+        // Write generated files
+        for (file in generatedOutput.files) {
+            writeGeneratedFile(file.relativePath, file.content)
+        }
+
+        return emptyList()
+    }
+
+    private fun extractClasses(resolver: Resolver): List<KSClassDeclaration> {
+        val classes = mutableListOf<KSClassDeclaration>()
+
+        // Find all classes with our annotations
+        val exportAnnotation = "io.github.kingg22.godot.api.annotations.Export"
+        val rpcAnnotation = "io.github.kingg22.godot.api.annotations.Rpc"
+        val toolAnnotation = "io.github.kingg22.godot.api.annotations.Tool"
+
+        resolver.getSymbolsWithAnnotation(exportAnnotation)
+            .filterIsInstance<KSClassDeclaration>()
+            .forEach { if (!classes.contains(it)) classes.add(it) }
+
+        resolver.getSymbolsWithAnnotation(rpcAnnotation)
+            .filterIsInstance<KSClassDeclaration>()
+            .forEach { if (!classes.contains(it)) classes.add(it) }
+
+        resolver.getSymbolsWithAnnotation(toolAnnotation)
+            .filterIsInstance<KSClassDeclaration>()
+            .forEach { if (!classes.contains(it)) classes.add(it) }
+
+        return classes
+    }
+
+    private fun runValidation(classes: List<KSClassDeclaration>): ValidationResultImpl {
+        val pipeline = ValidatorPipeline.empty()
+        val result = ValidationResultImpl()
+
+        for (ksClass in classes) {
+            val classInfo = ksClass.toClassInfo()
+            val context = ValidationContext(
+                classInfo = classInfo,
+                options = io.github.kingg22.kogot.processor.validation.ValidationOptions(),
+            )
+
+            val classResult = pipeline.execute(context, stopOnFirstError = false)
+            result.merge(classResult)
+
+            // Additional basic validation
+            if (classInfo.annotations.any { it.shortName == "Export" }) {
+                val exportedProps = classInfo.properties.filter {
+                    it.annotations.any { ann -> ann.shortName == "Export" }
+                }
+                for (prop in exportedProps) {
+                    // Basic type checking
+                    if (!isValidExportType(prop.type.qualifiedName)) {
+                        result.addError(
+                            DiagnosticMessage.error(
+                                code = DiagnosticCode.INVALID_EXPORT_TYPE,
+                                message = "@Export on unsupported type '${prop.type.qualifiedName}'",
+                                location = DiagnosticLocation(
+                                    classInfo.filePath,
+                                    classInfo.lineNumber,
+                                    0,
+                                ),
+                                help = "Supported types: primitives (Int, Float, String, etc.) and Godot builtin types",
+                                note = "This property will not appear in the Inspector",
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        return result
+    }
+
+    private fun isValidExportType(qualifiedName: String): Boolean {
+        val primitives = listOf(
+            "kotlin.Int",
+            "kotlin.Long",
+            "kotlin.Short",
+            "kotlin.Byte",
+            "kotlin.Float",
+            "kotlin.Double",
+            "kotlin.Boolean",
+            "kotlin.String",
+        )
+        return qualifiedName in primitives || qualifiedName.startsWith("io.github.kingg22.godot.api.builtin.")
+    }
+
+    private fun runGeneration(classes: List<KSClassDeclaration>): GeneratedOutput {
+        val classInfos = classes.map { it.toClassInfo() }
+        val context = GeneratorContext(
+            outputPackage = options.generatedPackage,
+            options = io.github.kingg22.kogot.processor.generation.GeneratorOptions(),
+        )
+
+        val outputs = mutableListOf<GeneratedOutput>()
+
+        // Generate Kotlin code if requested
+        if (options.outputMode == OutputMode.KOTLIN || options.outputMode == OutputMode.BOTH) {
+            val kotlinGenerator = KotlinGenerator()
+            outputs.add(kotlinGenerator.generate(context, classInfos))
+        }
+
+        // Generate JSON if requested
+        if (options.outputMode == OutputMode.JSON || options.outputMode == OutputMode.BOTH) {
+            val jsonGenerator = JsonGenerator()
+            outputs.add(jsonGenerator.generate(context, classInfos))
+        }
+
+        // Merge outputs
+        return GeneratedOutput(
+            files = outputs.flatMap { it.files },
+            diagnostics = outputs.flatMap { it.diagnostics },
+        )
+    }
+
+    private fun writeGeneratedFile(relativePath: String, content: String) {
+        // For now, just log that we would generate this file
+        logger.info("Would generate file: $relativePath with ${content.length} chars")
+    }
+
+    class Provider : SymbolProcessorProvider {
+        override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor = KogotProcessor(environment)
+    }
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/bridge/KspAnalysisContext.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/bridge/KspAnalysisContext.kt
@@ -1,0 +1,213 @@
+package io.github.kingg22.kogot.processor.bridge
+
+import com.google.devtools.ksp.isConstructor
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.FileLocation
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeReference
+import io.github.kingg22.kogot.analysis.context.AnalysisContext
+import io.github.kingg22.kogot.analysis.models.AnnotationInfo
+import io.github.kingg22.kogot.analysis.models.ClassInfo
+import io.github.kingg22.kogot.analysis.models.FunctionInfo
+import io.github.kingg22.kogot.analysis.models.ParameterInfo
+import io.github.kingg22.kogot.analysis.models.PropertyInfo
+import io.github.kingg22.kogot.analysis.models.TypeInfo
+
+/**
+ * KSP-specific implementation of AnalysisContext.
+ * Bridges KSP symbols to the backend-agnostic analysis layer.
+ */
+class KspAnalysisContext(private val resolver: Resolver) : AnalysisContext {
+    override val backend: String = "ksp"
+
+    // Simple cache for resolved classes
+    private val classCache = mutableMapOf<String, ClassInfo?>()
+
+    override fun resolveClass(qualifiedName: String): ClassInfo? {
+        classCache[qualifiedName]?.let { return it }
+
+        val ksClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString(qualifiedName))
+            ?: return null.also { classCache[qualifiedName] = null }
+
+        return ksClass.toClassInfo().also { classCache[qualifiedName] = it }
+    }
+
+    override fun getAllClasses(): List<ClassInfo> = emptyList()
+
+    override fun isGodotBuiltinType(qualifiedName: String): Boolean =
+        qualifiedName.startsWith("io.github.kingg22.godot.api.builtin.")
+
+    override fun isValidExportType(qualifiedName: String): Boolean {
+        if (qualifiedName in GodotBuiltinTypeNames.ALL) return true
+        if (isGodotBuiltinType(qualifiedName)) return true
+        return false
+    }
+
+    private object GodotBuiltinTypeNames {
+        val ALL = listOf(
+            "kotlin.Int",
+            "kotlin.Long",
+            "kotlin.Float",
+            "kotlin.Double",
+            "kotlin.Boolean",
+            "kotlin.String",
+            "kotlin.Byte",
+            "kotlin.Short",
+        )
+    }
+}
+
+/**
+ * Extension to convert KSClassDeclaration to ClassInfo.
+ */
+fun KSClassDeclaration.toClassInfo(): ClassInfo {
+    val packageName = packageName.asString()
+    val qName = this.qualifiedName
+    val qualifiedName = qName?.asString() ?: "$packageName.${simpleName.asString()}"
+
+    val annotations = this.annotations.map { it.toAnnotationInfo() }.toList()
+    val modifiers = this.modifiers.map { it.name }.toSet()
+
+    val supertypes = this.superTypes.mapNotNull { it.toTypeInfo() }.toList()
+
+    val properties = this.getAllProperties().map { it.toPropertyInfo() }.toList()
+    val functions = this.getAllFunctions().map { it.toFunctionInfo() }.toList()
+
+    val filePath = this.containingFile?.filePath ?: "<unknown>"
+    val line = this.getLineNumber()
+
+    return ClassInfo(
+        qualifiedName = qualifiedName,
+        shortName = simpleName.asString(),
+        packageName = packageName,
+        supertypes = supertypes,
+        properties = properties,
+        functions = functions,
+        annotations = annotations,
+        modifiers = modifiers,
+        filePath = filePath,
+        lineNumber = line,
+    )
+}
+
+/**
+ * Gets line number from a KSNode.
+ */
+private fun KSNode.getLineNumber(): Int {
+    val loc = this.location as? FileLocation ?: return 0
+    return loc.lineNumber
+}
+
+/**
+ * Extension to convert KSAnnotation to AnnotationInfo.
+ */
+fun KSAnnotation.toAnnotationInfo(): AnnotationInfo {
+    val annotationType = annotationType.resolve()
+    val decl = annotationType.declaration
+    val qualifiedName = (decl as? KSClassDeclaration)?.qualifiedName?.asString() ?: "<unknown>"
+    val shortName = (decl as? KSClassDeclaration)?.simpleName?.asString() ?: qualifiedName
+
+    val arguments = this.arguments.associate { arg ->
+        val name = arg.name?.asString() ?: "<unknown>"
+
+        val value = when (val v = arg.value) {
+            is KSType -> {
+                val typeDecl = v.declaration
+                if (typeDecl is KSClassDeclaration) {
+                    typeDecl.qualifiedName?.asString() ?: "unknown"
+                } else {
+                    "unknown"
+                }
+            }
+
+            is KSAnnotation -> v.toAnnotationInfo()
+
+            is List<*> -> v.toString()
+
+            else -> v
+        }
+        name to value
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return AnnotationInfo(
+        qualifiedName = qualifiedName,
+        shortName = shortName,
+        arguments = arguments.filterValues { it != null } as Map<String, Any>,
+    )
+}
+
+/**
+ * Extension to convert KSTypeReference to TypeInfo.
+ */
+fun KSTypeReference.toTypeInfo(): TypeInfo? {
+    val type = this.resolve().takeUnless { it.isError }
+    return type?.toTypeInfo()
+}
+
+/**
+ * Extension to convert KSType to TypeInfo.
+ */
+fun KSType.toTypeInfo(): TypeInfo {
+    val declaration = this.declaration
+    val declQName = declaration.qualifiedName
+    val qualifiedName = declQName?.asString() ?: "<unknown>"
+
+    return TypeInfo(
+        qualifiedName = qualifiedName,
+        shortName = declaration.simpleName.asString(),
+        isNullable = this.nullability == com.google.devtools.ksp.symbol.Nullability.NULLABLE,
+        isPrimitive = false,
+    )
+}
+
+/**
+ * Extension to convert KSPropertyDeclaration to PropertyInfo.
+ */
+fun KSPropertyDeclaration.toPropertyInfo(): PropertyInfo {
+    val typeInfo = type.toTypeInfo() ?: TypeInfo("<unknown>", "<unknown>")
+    val annotations = this.annotations.map { it.toAnnotationInfo() }.toList()
+    val modifiers = this.modifiers.map { it.name }.toSet()
+
+    return PropertyInfo(
+        name = simpleName.asString(),
+        type = typeInfo,
+        isMutable = this.isMutable,
+        hasDefaultValue = false,
+        annotations = annotations,
+        modifiers = modifiers,
+    )
+}
+
+/**
+ * Extension to convert KSFunctionDeclaration to FunctionInfo.
+ */
+fun KSFunctionDeclaration.toFunctionInfo(): FunctionInfo {
+    val returnTypeInfo = returnType?.toTypeInfo()
+    val annotations = this.annotations.map { it.toAnnotationInfo() }.toList()
+    val modifiers = this.modifiers.map { it.name }.toSet()
+
+    val parameters = this.parameters.map { param ->
+        ParameterInfo(
+            name = param.name?.asString() ?: "<param>",
+            type = param.type.toTypeInfo() ?: TypeInfo("<unknown>", "<unknown>"),
+            hasDefaultValue = param.hasDefault,
+        )
+    }
+
+    val simpleNameStr = simpleName.asString()
+
+    return FunctionInfo(
+        name = simpleNameStr,
+        returnType = returnTypeInfo,
+        parameters = parameters,
+        annotations = annotations,
+        modifiers = modifiers,
+        isConstructor = isConstructor(),
+    )
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticCode.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticCode.kt
@@ -1,0 +1,37 @@
+package io.github.kingg22.kogot.processor.diagnostics
+
+/**
+ * Unique identifier for a diagnostic (error/warning).
+ * Format: KOGOT-XXX (e.g., KOGOT-001, KOGOT-002)
+ */
+data class DiagnosticCode(val code: String, val category: Category) {
+    enum class Category {
+        EXTRACTION,
+        VALIDATION,
+        GENERATION,
+        INTERNAL,
+    }
+
+    companion object {
+        // Extraction errors
+        val UNABLE_TO_RESOLVE_TYPE = DiagnosticCode("KOGOT-001", Category.EXTRACTION)
+        val UNABLE_TO_RESOLVE_ANNOTATION = DiagnosticCode("KOGOT-002", Category.EXTRACTION)
+        val MALFORMED_ANNOTATION = DiagnosticCode("KOGOT-003", Category.EXTRACTION)
+
+        // Validation errors
+        val INVALID_EXPORT_TYPE = DiagnosticCode("KOGOT-101", Category.VALIDATION)
+        val INVALID_RPC_SIGNATURE = DiagnosticCode("KOGOT-102", Category.VALIDATION)
+        val INVALID_TOOL_CLASS = DiagnosticCode("KOGOT-103", Category.VALIDATION)
+        val INVALID_NAMING = DiagnosticCode("KOGOT-104", Category.VALIDATION)
+        val INVALID_GROUP_NAMING = DiagnosticCode("KOGOT-105", Category.VALIDATION)
+
+        // Generation errors
+        val GENERATION_FAILED = DiagnosticCode("KOGOT-201", Category.GENERATION)
+        val FILE_WRITE_FAILED = DiagnosticCode("KOGOT-202", Category.GENERATION)
+
+        // Internal errors
+        val INTERNAL_ERROR = DiagnosticCode("KOGOT-999", Category.INTERNAL)
+    }
+
+    override fun toString(): String = code
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticLocation.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticLocation.kt
@@ -1,0 +1,10 @@
+package io.github.kingg22.kogot.processor.diagnostics
+
+/**
+ * Represents a location in source code.
+ */
+data class DiagnosticLocation(val filePath: String, val line: Int, val column: Int) {
+    companion object {
+        val UNKNOWN = DiagnosticLocation("<unknown>", 0, 0)
+    }
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticMessage.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticMessage.kt
@@ -1,0 +1,64 @@
+package io.github.kingg22.kogot.processor.diagnostics
+
+/**
+ * A diagnostic message with rustc-style formatting.
+ *
+ * ```
+ * error[KOGOT-001]: @Export on invalid type
+ *   --> src/MyNode.kt:15:5
+ *    |
+ * 15 |     @Export var invalidProp: SomeClass
+ *    |         ^^^^^^^ Unsupported type 'SomeClass'. Supported: primitives, Godot types.
+ *    |
+ *    = help: Use a Godot built-in type or register a custom class
+ *    = note: This property will not appear in the Inspector
+ * ```
+ */
+data class DiagnosticMessage(
+    val code: DiagnosticCode,
+    val severity: Severity,
+    val mainMessage: String,
+    val location: DiagnosticLocation,
+    val contextLines: List<String> = emptyList(),
+    val help: String? = null,
+    val note: String? = null,
+) {
+    enum class Severity {
+        ERROR,
+        WARNING,
+        INFO,
+    }
+
+    fun isError(): Boolean = severity == Severity.ERROR
+    fun isWarning(): Boolean = severity == Severity.WARNING
+
+    companion object {
+        fun error(
+            code: DiagnosticCode,
+            message: String,
+            location: DiagnosticLocation,
+            help: String? = null,
+            note: String? = null,
+        ): DiagnosticMessage = DiagnosticMessage(
+            code = code,
+            severity = Severity.ERROR,
+            mainMessage = message,
+            location = location,
+            help = help,
+            note = note,
+        )
+
+        fun warning(
+            code: DiagnosticCode,
+            message: String,
+            location: DiagnosticLocation,
+            note: String? = null,
+        ): DiagnosticMessage = DiagnosticMessage(
+            code = code,
+            severity = Severity.WARNING,
+            mainMessage = message,
+            location = location,
+            note = note,
+        )
+    }
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticRenderer.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticRenderer.kt
@@ -1,0 +1,45 @@
+package io.github.kingg22.kogot.processor.diagnostics
+
+/**
+ * Renders diagnostics to various output formats.
+ */
+object DiagnosticRenderer {
+    /**
+     * Renders a diagnostic in rustc-style format.
+     */
+    fun renderRustc(message: DiagnosticMessage): String {
+        val sb = StringBuilder()
+        val severityStr = when (message.severity) {
+            ERROR -> "error"
+            WARNING -> "warning"
+            INFO -> "info"
+        }
+
+        sb.appendLine("$severityStr[${message.code}]: ${message.mainMessage}")
+        sb.appendLine("  --> ${message.location.filePath}:${message.location.line}:${message.location.column}")
+
+        if (message.contextLines.isNotEmpty()) {
+            sb.appendLine("   |")
+            message.contextLines.forEachIndexed { index, line ->
+                val lineNum = message.location.line - message.contextLines.size + index
+                sb.appendLine(" $lineNum | $line")
+            }
+            sb.appendLine("   |")
+        }
+
+        message.help?.let { help ->
+            sb.appendLine("   = help: $help")
+        }
+        message.note?.let { note ->
+            sb.appendLine("   = note: $note")
+        }
+
+        return sb.toString()
+    }
+
+    /**
+     * Renders a diagnostic in compact single-line format.
+     */
+    fun renderCompact(message: DiagnosticMessage): String =
+        "[${message.code}] ${message.location.filePath}:${message.location.line} - ${message.mainMessage}"
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/Generator.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/Generator.kt
@@ -1,0 +1,40 @@
+package io.github.kingg22.kogot.processor.generation
+
+import io.github.kingg22.kogot.analysis.models.ClassInfo
+import io.github.kingg22.kogot.processor.diagnostics.DiagnosticMessage
+
+/**
+ * Context for code generation.
+ */
+data class GeneratorContext(val outputPackage: String, val options: GeneratorOptions)
+
+/**
+ * Options for generators.
+ */
+data class GeneratorOptions(val generateKdoc: Boolean = true, val addSuppressAnnotations: Boolean = true)
+
+/**
+ * Output from a generator.
+ */
+data class GeneratedOutput(val files: List<GeneratedFile>, val diagnostics: List<DiagnosticMessage>)
+
+/**
+ * A generated file to be written.
+ */
+data class GeneratedFile(val relativePath: String, val content: String)
+
+/**
+ * Interface for code generators.
+ */
+interface Generator {
+    val name: String
+
+    /**
+     * Generates output files from the given class models.
+     *
+     * @param context The generation context
+     * @param classes The classes to generate code for
+     * @return GeneratedOutput containing files and any diagnostics
+     */
+    fun generate(context: GeneratorContext, classes: List<ClassInfo>): GeneratedOutput
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/json/JsonGenerator.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/json/JsonGenerator.kt
@@ -1,0 +1,78 @@
+package io.github.kingg22.kogot.processor.generation.json
+
+import io.github.kingg22.kogot.analysis.models.ClassInfo
+import io.github.kingg22.kogot.analysis.models.getExportedProperties
+import io.github.kingg22.kogot.analysis.models.getRpcFunctions
+import io.github.kingg22.kogot.analysis.models.hasTool
+import io.github.kingg22.kogot.processor.diagnostics.DiagnosticMessage
+import io.github.kingg22.kogot.processor.generation.GeneratedFile
+import io.github.kingg22.kogot.processor.generation.GeneratedOutput
+import io.github.kingg22.kogot.processor.generation.Generator
+import io.github.kingg22.kogot.processor.generation.GeneratorContext
+
+/**
+ * Generates JSON manifest for bindings.
+ */
+class JsonGenerator(private val prettyPrint: Boolean = true) : Generator {
+    override val name: String = "JsonGenerator"
+
+    override fun generate(context: GeneratorContext, classes: List<ClassInfo>): GeneratedOutput {
+        val files = mutableListOf<GeneratedFile>()
+        val diagnostics = mutableListOf<DiagnosticMessage>()
+
+        val manifest = buildManifest(classes)
+
+        files.add(
+            GeneratedFile(
+                relativePath = "manifest.json",
+                content = manifest,
+            ),
+        )
+
+        return GeneratedOutput(files, diagnostics)
+    }
+
+    private fun buildManifest(classes: List<ClassInfo>): String {
+        val sb = StringBuilder()
+        sb.appendLine("{")
+
+        val entries = classes.map { classInfo ->
+            buildClassEntry(classInfo)
+        }
+
+        sb.appendLine("  \"bindings\": [")
+        sb.append(entries.joinToString(",\n"))
+        sb.appendLine()
+        sb.appendLine("  ],")
+
+        val totalProps = classes.sumOf { it.getExportedProperties().size }
+        val totalRpc = classes.sumOf { it.getRpcFunctions().size }
+
+        sb.appendLine("  \"summary\": {")
+        sb.appendLine("    \"totalClasses\": ${classes.size},")
+        sb.appendLine("    \"totalExportedProperties\": $totalProps,")
+        sb.appendLine("    \"totalRpcFunctions\": $totalRpc")
+        sb.appendLine("  }")
+        sb.appendLine("}")
+
+        return sb.toString()
+    }
+
+    private fun buildClassEntry(classInfo: ClassInfo): String {
+        val exportedProps = classInfo.getExportedProperties()
+        val rpcFuncs = classInfo.getRpcFunctions()
+
+        val propNames = exportedProps.joinToString(", ") { "\"${it.name}\"" }
+        val rpcNames = rpcFuncs.joinToString(", ") { "\"${it.name}\"" }
+
+        return buildString {
+            appendLine("    {")
+            appendLine("      \"className\": \"${classInfo.shortName}\",")
+            appendLine("      \"qualifiedName\": \"${classInfo.qualifiedName}\",")
+            appendLine("      \"hasTool\": ${classInfo.hasTool()},")
+            appendLine("      \"exportedProperties\": [$propNames],")
+            appendLine("      \"rpcFunctions\": [$rpcNames]")
+            appendLine("    }")
+        }
+    }
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/kotlin/KotlinGenerator.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/kotlin/KotlinGenerator.kt
@@ -1,0 +1,108 @@
+package io.github.kingg22.kogot.processor.generation.kotlin
+
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.TypeSpec
+import io.github.kingg22.kogot.analysis.models.ClassInfo
+import io.github.kingg22.kogot.analysis.models.getExportedProperties
+import io.github.kingg22.kogot.analysis.models.getRpcFunctions
+import io.github.kingg22.kogot.processor.diagnostics.DiagnosticMessage
+import io.github.kingg22.kogot.processor.generation.GeneratedFile
+import io.github.kingg22.kogot.processor.generation.GeneratedOutput
+import io.github.kingg22.kogot.processor.generation.Generator
+import io.github.kingg22.kogot.processor.generation.GeneratorContext
+
+/**
+ * Generates Kotlin binding code for annotated classes.
+ */
+class KotlinGenerator : Generator {
+    override val name: String = "KotlinGenerator"
+
+    override fun generate(context: GeneratorContext, classes: List<ClassInfo>): GeneratedOutput {
+        val files = mutableListOf<GeneratedFile>()
+        val diagnostics = mutableListOf<DiagnosticMessage>()
+
+        for (classInfo in classes) {
+            try {
+                val file = generateBindingFile(classInfo, context)
+                files.add(GeneratedFile(file.relativePath, file.content))
+            } catch (e: Exception) {
+                diagnostics.add(
+                    DiagnosticMessage.error(
+                        code = io.github.kingg22.kogot.processor.diagnostics.DiagnosticCode.GENERATION_FAILED,
+                        message = "Failed to generate binding for ${classInfo.qualifiedName}: ${e.message}",
+                        location = io.github.kingg22.kogot.processor.diagnostics.DiagnosticLocation(
+                            classInfo.filePath,
+                            classInfo.lineNumber,
+                            0,
+                        ),
+                    ),
+                )
+            }
+        }
+
+        return GeneratedOutput(files, diagnostics)
+    }
+
+    private fun generateBindingFile(classInfo: ClassInfo, context: GeneratorContext): GeneratedFile {
+        val bindingClassName = "${classInfo.shortName}Binding"
+        val packageName = context.outputPackage
+
+        val fileSpec = FileSpec.builder(packageName, bindingClassName)
+
+        // Add suppress annotation if configured
+        if (context.options.addSuppressAnnotations) {
+            fileSpec.addAnnotation(
+                com.squareup.kotlinpoet.AnnotationSpec.builder(Suppress::class)
+                    .addMember("\"UNUSED\"")
+                    .build(),
+            )
+        }
+
+        val typeSpec = TypeSpec.classBuilder(bindingClassName)
+
+        // Add KDoc if configured
+        if (context.options.generateKdoc) {
+            typeSpec.addKdoc("Generated binding for %L\n", classInfo.qualifiedName)
+            typeSpec.addKdoc("\nThis class is auto-generated. Do not modify manually.")
+        }
+
+        // Add companion object with registration function
+        val companion = TypeSpec.companionObjectBuilder()
+
+        val registerFun = FunSpec.builder("register")
+            .addStatement("println(%S)", "Registering binding for ${classInfo.shortName}")
+
+        // Register exported properties
+        val exportedProps = classInfo.getExportedProperties()
+        for (prop in exportedProps) {
+            registerFun.addStatement(
+                "// Register property: %L",
+                prop.name,
+            )
+        }
+
+        // Register RPC functions
+        val rpcFuncs = classInfo.getRpcFunctions()
+        for (rpc in rpcFuncs) {
+            registerFun.addStatement(
+                "// Register RPC: %L",
+                rpc.name,
+            )
+        }
+
+        companion.addFunction(registerFun.build())
+        typeSpec.addType(companion.build())
+
+        fileSpec.addType(typeSpec.build())
+
+        val builtFile = fileSpec.build()
+        val content = StringBuilder()
+        builtFile.writeTo(content)
+
+        return GeneratedFile(
+            relativePath = "${packageName.replace('.', '/')}/$bindingClassName.kt",
+            content = content.toString(),
+        )
+    }
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/validation/ValidationContext.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/validation/ValidationContext.kt
@@ -1,0 +1,38 @@
+package io.github.kingg22.kogot.processor.validation
+
+import io.github.kingg22.kogot.analysis.models.ClassInfo
+
+/**
+ * Shared state used during validation.
+ */
+data class ValidationContext(val classInfo: ClassInfo, val options: ValidationOptions)
+
+/**
+ * Options that affect validation behavior.
+ */
+data class ValidationOptions(val allowExperimental: Boolean = false, val strictNaming: Boolean = true)
+
+/**
+ * Base interface for validators.
+ */
+interface Validator {
+    val name: String
+
+    /**
+     * Validates the class and returns validation result.
+     *
+     * @param context The validation context
+     * @return ValidationResult containing any errors/warnings found
+     */
+    fun validate(context: ValidationContext): ValidationResult
+}
+
+/**
+ * A validator that can also enrich the model with additional info.
+ */
+interface EnrichingValidator : Validator {
+    /**
+     * Returns true if this validator can handle the given class.
+     */
+    fun canHandle(classInfo: ClassInfo): Boolean
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/validation/ValidationResult.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/validation/ValidationResult.kt
@@ -1,0 +1,41 @@
+package io.github.kingg22.kogot.processor.validation
+
+import io.github.kingg22.kogot.processor.diagnostics.DiagnosticMessage
+
+/**
+ * Accumulates validation errors and warnings.
+ */
+interface ValidationResult {
+    val errors: List<DiagnosticMessage>
+    val warnings: List<DiagnosticMessage>
+    val isValid: Boolean
+
+    fun addError(message: DiagnosticMessage)
+    fun addWarning(message: DiagnosticMessage)
+    fun merge(other: ValidationResult)
+}
+
+/**
+ * Implementation of ValidationResult.
+ */
+class ValidationResultImpl : ValidationResult {
+    private val _errors = mutableListOf<DiagnosticMessage>()
+    private val _warnings = mutableListOf<DiagnosticMessage>()
+
+    override val errors: List<DiagnosticMessage> get() = _errors
+    override val warnings: List<DiagnosticMessage> get() = _warnings
+    override val isValid: Boolean get() = _errors.isEmpty()
+
+    override fun addError(message: DiagnosticMessage) {
+        _errors.add(message)
+    }
+
+    override fun addWarning(message: DiagnosticMessage) {
+        _warnings.add(message)
+    }
+
+    override fun merge(other: ValidationResult) {
+        _errors.addAll(other.errors)
+        _warnings.addAll(other.warnings)
+    }
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/validation/ValidatorPipeline.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/validation/ValidatorPipeline.kt
@@ -1,0 +1,40 @@
+package io.github.kingg22.kogot.processor.validation
+
+/**
+ * Orchestrates execution of multiple validators in sequence.
+ */
+class ValidatorPipeline(private val validators: List<Validator>) {
+    /**
+     * Executes all validators in order, aggregating results.
+     *
+     * @param context The validation context
+     * @param stopOnFirstError If true, stops at first fatal error
+     * @return Combined ValidationResult
+     */
+    fun execute(context: ValidationContext, stopOnFirstError: Boolean = true): ValidationResult {
+        val combinedResult = ValidationResultImpl()
+
+        for (validator in validators) {
+            val result = validator.validate(context)
+            combinedResult.merge(result)
+
+            if (stopOnFirstError && !result.isValid) {
+                break
+            }
+        }
+
+        return combinedResult
+    }
+
+    /**
+     * Creates a new pipeline with an additional validator.
+     */
+    fun with(validator: Validator): ValidatorPipeline = ValidatorPipeline(validators + validator)
+
+    companion object {
+        /**
+         * Creates an empty pipeline.
+         */
+        fun empty(): ValidatorPipeline = ValidatorPipeline(emptyList())
+    }
+}

--- a/processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+io.github.kingg22.kogot.processor.KogotProcessor$Provider

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -82,5 +82,5 @@ project(":kotlin-native-api").projectDir = file("kotlin-native/api")
 project(":kotlin-native-runtime").projectDir = file("kotlin-native/runtime")
 project(":kotlin-native-sample").projectDir = file("kotlin-native/sample")
 
-// codegen and processor
-include("codegen", "processor")
+// codegen, processor, and analysis
+include("codegen", "processor", "analysis")


### PR DESCRIPTION
First step of #26

## Summary by Sourcery

Introducir una canalización de procesador basada en KSP respaldada por un módulo de análisis reutilizable y generadores iniciales de Kotlin/JSON para los bindings de Godot.

New Features:
- Añadir un módulo de análisis independiente del backend con modelos centrales, extractores, resolvedores e interfaces de contexto para el análisis de clases y anotaciones.
- Implementar el procesador Kogot KSP inicial con opciones, canalización de validación y flujo de generación para bindings.
- Proporcionar un generador de código Kotlin usando KotlinPoet y un generador de manifiestos JSON para clases anotadas.

Enhancements:
- Conectar los nuevos módulos de análisis y procesador en la compilación de Gradle, incluyendo las dependencias de procesamiento de KSP y del compilador de Room.

Documentation:
- Añadir un documento detallado de arquitectura y diseño que describe el módulo de análisis, la canalización del procesador, los diagnósticos y la extensibilidad.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a KSP-based processor pipeline backed by a reusable analysis module and initial Kotlin/JSON generators for Godot bindings.

New Features:
- Add backend-agnostic analysis module with core models, extractors, resolvers, and context interfaces for class and annotation analysis.
- Implement initial Kogot KSP processor with options, validation pipeline, and generation flow for bindings.
- Provide Kotlin code generator using KotlinPoet and a JSON manifest generator for annotated classes.

Enhancements:
- Wire the new analysis and processor modules into the Gradle build, including KSP and Room compiler processing dependencies.

Documentation:
- Add detailed architecture and design document describing the analysis module, processor pipeline, diagnostics, and extensibility.

</details>