### PR TITLE
chore: add support for callable from a kotlin lambda/function

### DIFF
--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/TypedContainers.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/TypedContainers.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // TODO find a better API to obtain the type of a Variant, or remove all overloads
+
 package io.github.kingg22.godot.api.builtin
 
 import io.github.kingg22.godot.api.ExperimentalGodotKotlin

--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/Utils.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/Utils.kt
@@ -1,11 +1,9 @@
 package io.github.kingg22.godot.api.builtin
 
 import io.github.kingg22.godot.api.ExperimentalGodotKotlin
+import io.github.kingg22.godot.api.builtin.internal.anyToVariant
 import io.github.kingg22.godot.api.builtin.internal.checkVariantCompatibility
-import io.github.kingg22.godot.api.builtin.internal.checkVariantTypeAndConvert
-import io.github.kingg22.godot.api.builtin.internal.variantTypeOf
 import kotlin.reflect.KProperty
-import kotlin.reflect.typeOf
 
 public fun String.asGodotString(): GodotString = GodotString(this)
 
@@ -21,36 +19,36 @@ public fun String?.asVariantNodePath(): Variant = this?.asNodePath().use { it.as
 
 /** CAUTION: Read docs of [from] converter */
 @ExperimentalGodotKotlin
-public inline fun <reified T> T?.asVariant(): Variant = Variant.from(this)
+public inline fun <reified T> T?.asVariant(): Variant = anyToVariant(this)
 
 /**
  * Converts an element to a [Variant] with type checking.
  *
  * This is unsafe, use caution. Prefers explicit convert methods over this function.
  *
- * [CPointer][kotlinx.cinterop.COpaquePointer] is not supported, use
- * [Object][io.github.kingg22.godot.api.core.GodotObject] or
- * primary constructor of Variant if you are sure it is a Variant pointer instead.
+ * **Safety**:
+ * - [CPointer][kotlinx.cinterop.COpaquePointer] is not supported, use
+ * [Object][io.github.kingg22.godot.api.core.GodotObject] if it's an Object pointer or
+ * primary constructor of Variant if it's a Variant pointer instead.
+ * - [kotlin.String] is mapped to [GodotString] and box to [Variant]
  */
 @ExperimentalGodotKotlin
-public inline fun <reified T> Variant.Companion.from(element: @MustBeVariant T): Variant = checkVariantTypeAndConvert(
-    element = element,
-    type = variantTypeOf(typeOf<T>()),
-)
+public inline fun <reified T> Variant.Companion.from(element: @MustBeVariant T): Variant = anyToVariant(this)
 
 /**
  * Syntactic sugar for [Variant.getValue] with type checking and inferred return type.
  *
  * Must prefer explicit convert methods over this operator.
+ *
+ * **Safety**:
+ * - [kotlin.String] is not supported **yet**, use [GodotString] instead
  */
 @ExperimentalGodotKotlin
 public inline operator fun <@MustBeVariant reified T> Variant.getValue(thisRef: T?, property: KProperty<*>): T {
-    val type = getType()
-    checkVariantCompatibility<T>(type)
     if (T::class == String::class) {
         error("Cannot provide kotlin String, must use GodotString instead or explicit convert method")
     }
     val value = getValue()
-    @Suppress("UNCHECKED_CAST")
-    return value as T
+    if (value !is T) error("Expected ${T::class} but got ${value?.let { it::class }}")
+    return value
 }

--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/VariantValue.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/VariantValue.kt
@@ -6,6 +6,10 @@ import io.github.kingg22.godot.api.ExperimentalGodotKotlin
  * Returns the value of this [Variant].
  *
  * Prefers explicit converter method over this function.
+ *
+ * Doesn't return [kotlin.String]!!
+ *
+ * @throws [IllegalStateException] if the type of variant is [MAX][Variant.Type.MAX]
  */
 @ExperimentalGodotKotlin
 public fun Variant.getValue(): @MustBeVariant Any? = when (getType()) {

--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/internal/ConvertToVariant.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/internal/ConvertToVariant.kt
@@ -1,0 +1,67 @@
+package io.github.kingg22.godot.api.builtin.internal
+
+import io.github.kingg22.godot.api.ExperimentalGodotKotlin
+import io.github.kingg22.godot.api.builtin.*
+import io.github.kingg22.godot.api.core.GodotObject
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * Converts an arbitrary type to a [Variant].
+ *
+ * Equivalent to call `asVariant()` on the type.
+ * @param element The element to convert, [must be a variant type compatible][MustBeVariant].
+ * @see Variant
+ * @see GodotObject.asVariant
+ */
+@ExperimentalGodotKotlin
+@ApiStatus.Internal
+public fun <T> anyToVariant(element: @MustBeVariant T?): Variant {
+    // Manejo explícito de null → Variant NIL
+    if (element == null) return Variant()
+
+    return when (element) {
+        is Variant -> element
+        is Boolean -> element.asVariant()
+        is Int -> element.asVariant()
+        is Long -> element.asVariant()
+        is Float -> element.asVariant()
+        is Double -> element.asVariant()
+        is String -> element.asVariantString()
+        is GodotString -> element.asVariant()
+        is StringName -> element.asVariant()
+        is NodePath -> element.asVariant()
+        is Vector2 -> element.asVariant()
+        is Vector2i -> element.asVariant()
+        is Rect2 -> element.asVariant()
+        is Rect2i -> element.asVariant()
+        is Vector3 -> element.asVariant()
+        is Vector3i -> element.asVariant()
+        is Vector4 -> element.asVariant()
+        is Vector4i -> element.asVariant()
+        is Transform2D -> element.asVariant()
+        is Transform3D -> element.asVariant()
+        is Plane -> element.asVariant()
+        is Quaternion -> element.asVariant()
+        is AABB -> element.asVariant()
+        is Basis -> element.asVariant()
+        is Projection -> element.asVariant()
+        is Color -> element.asVariant()
+        is Rid -> element.asVariant()
+        is Callable -> element.asVariant()
+        is Signal -> element.asVariant()
+        is GodotObject -> element.asVariant()
+        is Dictionary<*, *> -> element.asVariant()
+        is GodotArray<*> -> element.asVariant()
+        is PackedByteArray -> element.asVariant()
+        is PackedInt32Array -> element.asVariant()
+        is PackedInt64Array -> element.asVariant()
+        is PackedFloat32Array -> element.asVariant()
+        is PackedFloat64Array -> element.asVariant()
+        is PackedStringArray -> element.asVariant()
+        is PackedVector2Array -> element.asVariant()
+        is PackedVector3Array -> element.asVariant()
+        is PackedVector4Array -> element.asVariant()
+        is PackedColorArray -> element.asVariant()
+        else -> error("Unsupported type for Variant: $element (${element::class})")
+    }
+}

--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/internal/VariantTypeCheck.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/builtin/internal/VariantTypeCheck.kt
@@ -3,20 +3,25 @@ package io.github.kingg22.godot.api.builtin.internal
 import io.github.kingg22.godot.api.ExperimentalGodotKotlin
 import io.github.kingg22.godot.api.builtin.*
 import io.github.kingg22.godot.api.core.GodotObject
-import io.github.kingg22.godot.api.utils.GD
-import io.github.kingg22.godot.api.utils.pushError
 import org.jetbrains.annotations.ApiStatus
 import kotlin.contracts.contract
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
+/**
+ * Convert a [KType] to a [Variant.Type]
+ *
+ * **Safety**:
+ * - [Unit] is not supported, returns [Variant.Type.NIL] as fallback
+ * - Inheritance of [GodotObject] is not supported
+ * - [Variant] is not supported
+ */
+@Deprecated("This function doesn't support inheritance of GodotObject, prefers others methods", level = WARNING)
 @ExperimentalGodotKotlin
 @ApiStatus.Internal
 public fun variantTypeOf(kType: KType): Variant.Type = when (kType) {
     typeOf<Unit>() -> {
-        GD.pushError(
-            "Variant of Unit is not supported, returning Variant.Type.NIL as fallback, define the type explicitly",
-        )
+        println("Variant of Unit is not supported, returning Variant.Type.NIL as fallback, define the type explicitly")
         Variant.Type.NIL
     }
 
@@ -68,6 +73,8 @@ public fun variantTypeOf(kType: KType): Variant.Type = when (kType) {
 
     typeOf<RID>() -> Variant.Type.RID
 
+    typeOf<GodotObject>() -> Variant.Type.OBJECT
+
     typeOf<Callable>() -> Variant.Type.CALLABLE
 
     typeOf<Signal>() -> Variant.Type.SIGNAL
@@ -96,24 +103,18 @@ public fun variantTypeOf(kType: KType): Variant.Type = when (kType) {
 
     typeOf<PackedVector4Array>() -> Variant.Type.PACKED_VECTOR4_ARRAY
 
-    else -> {
-        // fallback: GodotObject o script
-        when (kType.classifier) {
-            GodotObject::class -> Variant.Type.OBJECT
-            GodotArray::class -> Variant.Type.ARRAY
-            Dictionary::class -> Variant.Type.DICTIONARY
-            else -> error("Unsupported type for Variant: $kType")
-        }
-    }
+    else -> error("Unsupported type for Variant: $kType, must be explicitly type defined")
 }
 
 /** Compatible Variant.Type for kotlin String */
 @PublishedApi
 internal val stringToTypes: Array<Variant.Type> = arrayOf(STRING, STRING_NAME, NODE_PATH)
 
+@Deprecated("This function doesn't support inheritance of GodotObject, prefers others methods", level = WARNING)
 @ExperimentalGodotKotlin
 @ApiStatus.Internal
 public inline fun <@MustBeVariant reified T> checkVariantCompatibility(type: Variant.Type) {
+    @Suppress("DEPRECATION") // this is deprecated too
     val expected = variantTypeOf(typeOf<T>())
     require(type == expected || (T::class == String::class && type in stringToTypes)) {
         "Variant.Type mismatch: expected=$expected but got=$type for T=${T::class}"

--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/signal/Signal1.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/signal/Signal1.kt
@@ -6,7 +6,6 @@ import io.github.kingg22.godot.api.builtin.MustBeVariant
 import io.github.kingg22.godot.api.builtin.StringName
 import io.github.kingg22.godot.api.builtin.asGodotString
 import io.github.kingg22.godot.api.builtin.internal.checkVariantTypeAndConvert
-import io.github.kingg22.godot.api.builtin.internal.variantTypeOf
 import io.github.kingg22.godot.api.core.GodotObject
 import io.github.kingg22.godot.api.internal.checkGodotError
 
@@ -47,11 +46,13 @@ public class Signal1<@MustBeVariant P1>(
      * @param p1 The first parameter value
      */
     public fun emit(p1: P1) {
-        val variantType = variantTypeOf(param1.kType)
-        val arg1 = checkVariantTypeAndConvert(p1, variantType)
-        StringName(name).use { signalName ->
-            checkGodotError("emit signal: $nameKString", owner.emitSignal(signalName, arg1))
-        }
+        val arg1 = checkVariantTypeAndConvert(p1, param1.variantType)
+        checkGodotError(
+            "emit signal: $nameKString",
+            StringName(name).use { signalName ->
+                owner.emitSignal(signalName, arg1)
+            },
+        )
     }
 
     /**
@@ -65,9 +66,12 @@ public class Signal1<@MustBeVariant P1>(
             @Suppress("UNCHECKED_CAST")
             callback(args[0] as P1)
         }
-        StringName(name).use { signalName ->
-            checkGodotError("connect signal: $nameKString", owner.connect(signalName, callable, flags.value.toUInt()))
-        }
+        checkGodotError(
+            "connect signal: $nameKString",
+            StringName(name).use { signalName ->
+                owner.connect(signalName, callable, flags.value.toUInt())
+            },
+        )
     }
 
     /**

--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/signal/SignalParamFactory.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/signal/SignalParamFactory.kt
@@ -1,5 +1,6 @@
 package io.github.kingg22.godot.api.signal
 
+import io.github.kingg22.godot.api.builtin.MustBeVariant
 import kotlin.reflect.typeOf
 
 /**
@@ -10,5 +11,5 @@ import kotlin.reflect.typeOf
  * signal("vida_cambio", param<Int>("nueva_vida"))
  * ```
  */
-public inline fun <reified P> param(name: String): SignalParameterDescriptor<P> =
+public inline fun <@MustBeVariant reified P> param(name: String): SignalParameterDescriptor<P> =
     SignalParameterDescriptor(name, typeOf<P>())

--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/signal/SignalParameterDescriptor.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/signal/SignalParameterDescriptor.kt
@@ -2,6 +2,8 @@ package io.github.kingg22.godot.api.signal
 
 import io.github.kingg22.godot.api.ExperimentalGodotKotlin
 import io.github.kingg22.godot.api.builtin.MustBeVariant
+import io.github.kingg22.godot.api.builtin.Variant
+import io.github.kingg22.godot.api.builtin.internal.variantTypeOf
 import kotlin.reflect.KType
 
 /**
@@ -19,5 +21,8 @@ public class SignalParameterDescriptor<@MustBeVariant P> @ExperimentalGodotKotli
     public val name: String,
     public val kType: KType,
 ) {
+    @Suppress("DEPRECATION") // TODO find a better way to do this
+    public val variantType: Variant.Type = variantTypeOf(kType)
+
     public val isOptional: Boolean get() = kType.isMarkedNullable
 }

--- a/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/signal/Utils.kt
+++ b/kotlin-native/api/src/nativeMain/kotlin/io/github/kingg22/godot/api/signal/Utils.kt
@@ -3,24 +3,24 @@ package io.github.kingg22.godot.api.signal
 import io.github.kingg22.godot.api.builtin.Callable
 
 // ---------------------------------------------------------------------------
-// Internal callable creation (placeholder - needs runtime binding support)
+// Internal callable creation
 // ---------------------------------------------------------------------------
 
 /**
  * Creates a Godot [Callable] from a Kotlin lambda.
  *
- * TODO: This is a placeholder. The actual implementation requires:
- * - A callback/trampoline mechanism in the native runtime
- * - Memory management for the callback closure
- * - Integration with Godot's callable system
+ * This is a placeholder implementation. The full implementation requires:
+ * - A callback/trampoline mechanism in the native runtime (CallableTrampolines)
+ * - Integration with Godot's callable_custom_create2
  *
- * One approach is to create a static callback object that dispatches
- * to a closure stored via a key in a global WeakMap.
+ * Currently returns an empty callable for compilation.
  */
 @PublishedApi
 @Suppress("UNUSED_PARAMETER")
 internal inline fun <R : Any> createCallable(callback: (Array<Any?>) -> R): Callable {
-    // TODO: Implementation requires native callback trampoline
-    // For now, return empty callable as placeholder
+    // TODO: When CallableFactory is implemented, use:
+    // return CallableFactory.create(callback)
+
+    // For now, return empty callable (placeholder - signal connections won't work)
     return Callable()
 }

--- a/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/Callable0.kt
+++ b/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/Callable0.kt
@@ -1,0 +1,13 @@
+package io.github.kingg22.godot.internal.callback
+
+/**
+ * Wrapper class for a callable with no arguments.
+ */
+@PublishedApi
+internal class Callable0<R>(private val lambda: () -> R) : KotlinCallable {
+    override fun call(args: Array<Any?>): Any? = lambda()
+    override fun arity(): Int = 0
+    override fun hash(): Int = lambda.hashCode()
+    override fun equals(other: KotlinCallable): Boolean = other is Callable0<*> && lambda == other.lambda
+    override fun toString(): String = "Callable0(lambda=$lambda)"
+}

--- a/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/CallableFactory.kt
+++ b/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/CallableFactory.kt
@@ -1,0 +1,123 @@
+@file:OptIn(ExperimentalGodotKotlin::class) // safety, or throws an acceptable exception
+
+package io.github.kingg22.godot.internal.callback
+
+import io.github.kingg22.godot.api.ExperimentalGodotKotlin
+import io.github.kingg22.godot.api.builtin.Callable
+import io.github.kingg22.godot.api.builtin.MustBeVariant
+import io.github.kingg22.godot.api.builtin.Variant
+import io.github.kingg22.godot.api.builtin.asVariant
+import io.github.kingg22.godot.internal.binding.BindingProcAddressHolder
+import io.github.kingg22.godot.internal.binding.CallableBinding
+import io.github.kingg22.godot.internal.binding.InternalBinding
+import io.github.kingg22.godot.internal.binding.VariantBinding
+import io.github.kingg22.godot.internal.binding.getInstance
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomCall
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomInfo2
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.cValue
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.staticCFunction
+
+/**
+ * Factory for creating Godot custom Callables from Kotlin lambdas.
+ *
+ * Usage:
+ * ```
+ * val callable = CallableFactory.create { println("Hello!") }
+ * callable.callDeferred(node, StringName("my_method"))
+ * ```
+ */
+@InternalBinding
+public object CallableFactory {
+    /**
+     * Creates a Godot Callable from a Kotlin lambda with 0 arguments.
+     *
+     * @param T The return type of the lambda must be a [Variant type compatible][MustBeVariant].
+     * Allows [Unit] as return type, is converted to [Variant.Type.NIL] internally.
+     * @param lambda The Kotlin lambda to wrap
+     * @return A Callable that wraps the Kotlin lambda
+     */
+    public inline fun <@MustBeVariant reified T> create(noinline lambda: () -> T): Callable {
+        // Create a KotlinCallable wrapper
+        val kotlinCallable = Callable0(lambda)
+
+        // Register it in the map and get a unique ID
+        val id = CallableUserdataMap.add(kotlinCallable)
+
+        // Create a StableRef to hold the ID as userdata
+        val userdata = StableRef.create(id).asCPointer()
+
+        // Create the GDExtensionCallableCustomInfo2 struct using cValue
+        val callableCustomInfo2 = createCallableCustomInfo2(
+            userdata,
+            staticCFunction { userdata, _, argumentCount, rReturn, rError ->
+                val callable = CallableUserdataMap.get(userdata.getInstance()) ?: return@staticCFunction
+
+                if (rReturn == null || rError == null) return@staticCFunction
+
+                if (argumentCount != 0L) {
+                    println("[kogot]: Error: callable called with $argumentCount arguments, expected 0")
+                    val callError = rError[0]
+                    callError.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS
+                    callError.expected = 0
+                    callError.argument = argumentCount.toInt()
+                    return@staticCFunction
+                }
+
+                // TODO: properly convert arguments to Kotlin types using Variant
+                val result = runCatching { callable.call(emptyArray()) }.getOrElse {
+                    println("[kogot]: Error calling callable 0 args, fallback to null: $it")
+                    null
+                }
+
+                val resultVariant = when (result) {
+                    null, is Unit -> Variant()
+
+                    is Variant -> result
+
+                    else -> runCatching { result.asVariant() }.getOrElse {
+                        println("[kogot]: Error converting callable result ($result) to Variant, fallback to null: $it")
+                        Variant()
+                    }
+                }
+
+                VariantBinding.instance.newCopyRaw(rReturn, resultVariant.rawPtr)
+            },
+        )
+
+        // Create the empty Callable
+        val callable = Callable()
+
+        // Call the low-level Godot function to create custom callable and fill the callable object
+        memScoped {
+            CallableBinding.instance.customCreate2Raw(
+                callable.rawPtr,
+                callableCustomInfo2.ptr,
+            )
+        }
+
+        return callable
+    }
+
+    @PublishedApi
+    internal fun createCallableCustomInfo2(
+        userdata: COpaquePointer,
+        call: GDExtensionCallableCustomCall,
+    ): CValue<GDExtensionCallableCustomInfo2> = cValue {
+        callable_userdata = userdata
+        token = BindingProcAddressHolder.library
+        object_id = 0uL // custom, not bind to object
+        call_func = call
+        is_valid_func = CallableTrampolines.isValidFunc
+        free_func = CallableTrampolines.freeFunc
+        hash_func = CallableTrampolines.hashFunc
+        equal_func = CallableTrampolines.equalFunc
+        less_than_func = CallableTrampolines.lessThanFunc
+        to_string_func = CallableTrampolines.toStringFunc
+        get_argument_count_func = CallableTrampolines.getArgumentCountFunc
+    }
+}

--- a/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/CallableTrampolines.kt
+++ b/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/CallableTrampolines.kt
@@ -1,0 +1,115 @@
+package io.github.kingg22.godot.internal.callback
+
+import io.github.kingg22.godot.internal.binding.InternalBinding
+import io.github.kingg22.godot.internal.binding.StringBinding
+import io.github.kingg22.godot.internal.binding.getInstance
+import io.github.kingg22.godot.internal.ffi.FALSE
+import io.github.kingg22.godot.internal.ffi.GDExtensionBool
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomEqual
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomFree
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomGetArgumentCount
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomHash
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomIsValid
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomLessThan
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomToString
+import io.github.kingg22.godot.internal.ffi.TRUE
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.asStableRef
+import kotlinx.cinterop.set
+import kotlinx.cinterop.staticCFunction
+
+/**
+ * Static C trampolines for custom callable callbacks.
+ *
+ * These trampolines are invoked by Godot when a custom callable is called.
+ * They extract the userdata (which is a StableRef containing a Long ID),
+ * retrieve the KotlinCallable from the map, and dispatch to it.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@InternalBinding
+public object CallableTrampolines {
+
+    /**
+     * Free trampoline - invoked when the callable is destroyed.
+     * Cleans up the userdata from the map.
+     */
+    public val freeFunc: GDExtensionCallableCustomFree = staticCFunction { userdata ->
+        val ref = requireNotNull(userdata).asStableRef<Long>()
+        val id = ref.get()
+        CallableUserdataMap.remove(id)
+        ref.dispose()
+    }
+
+    /**
+     * Hash trampoline - returns hash of the callable.
+     */
+    public val hashFunc: GDExtensionCallableCustomHash = staticCFunction { userdata ->
+        CallableUserdataMap.get(userdata.getInstance())?.hash()?.toUInt() ?: 0u
+    }
+
+    /**
+     * Is valid trampoline - checks if callable is still valid.
+     */
+    public val isValidFunc: GDExtensionCallableCustomIsValid = staticCFunction { userdata ->
+        val id = userdata.getInstance<Long>()
+        val callable = CallableUserdataMap.get(id)
+        if (callable != null && callable.isValid()) GDExtensionBool.TRUE else GDExtensionBool.FALSE
+    }
+
+    /**
+     * Equal trampoline - checks equality with another callable.
+     */
+    public val equalFunc: GDExtensionCallableCustomEqual = staticCFunction { userdataA, userdataB ->
+        val callableA = CallableUserdataMap.get(userdataA.getInstance())
+        val callableB = CallableUserdataMap.get(userdataB.getInstance())
+        if (callableA != null && callableB != null &&
+            callableA.equals(callableB)
+        ) {
+            GDExtensionBool.TRUE
+        } else {
+            GDExtensionBool.FALSE
+        }
+    }
+
+    /**
+     * Less than trampoline - comparison for sorting.
+     */
+    public val lessThanFunc: GDExtensionCallableCustomLessThan = staticCFunction { userdataA, userdataB ->
+        val callableA = CallableUserdataMap.get(userdataA.getInstance())
+        val callableB = CallableUserdataMap.get(userdataB.getInstance())
+        if (callableA != null && callableB != null &&
+            callableA.lessThan(callableB)
+        ) {
+            GDExtensionBool.TRUE
+        } else {
+            GDExtensionBool.FALSE
+        }
+    }
+
+    /**
+     * Argument count trampoline - returns the number of arguments.
+     */
+    public val getArgumentCountFunc: GDExtensionCallableCustomGetArgumentCount = staticCFunction { userdata, rIsValid ->
+        val callable = CallableUserdataMap.get(userdata.getInstance())
+        val arity = callable?.arity()?.toLong() ?: 0L
+        if (rIsValid != null) {
+            val validFlag = if (callable != null && callable.isValid()) GDExtensionBool.TRUE else GDExtensionBool.FALSE
+            rIsValid[0] = validFlag
+        }
+        arity
+    }
+
+    /**
+     * To string trampoline - returns string representation for debugging.
+     */
+    public val toStringFunc: GDExtensionCallableCustomToString = staticCFunction { userdata, rIsValid, rReturnPtr ->
+        val callableId = userdata.getInstance<Long>()
+        val callable = CallableUserdataMap.get(callableId)
+        if (rIsValid != null) {
+            val validFlag = if (callable != null && callable.isValid()) GDExtensionBool.TRUE else GDExtensionBool.FALSE
+            rIsValid[0] = validFlag
+        }
+        val string = callable?.toString() ?: "Invalid Callable"
+        StringBinding.instance.newWithUtf8Chars(rReturnPtr, string)
+    }
+}

--- a/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/CallableUserdataMap.kt
+++ b/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/CallableUserdataMap.kt
@@ -1,0 +1,35 @@
+package io.github.kingg22.godot.internal.callback
+
+import io.github.kingg22.godot.internal.binding.InternalBinding
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+
+/**
+ * Global map storing KotlinCallable instances with unique IDs for callable userdata.
+ *
+ * This map serves as the bridge between Godot's custom callable system (which uses
+ * opaque userdata pointers) and Kotlin lambdas. Each lambda is assigned a unique
+ * ID that is passed as the userdata to Godot, allowing the trampolines to
+ * retrieve the original lambda.
+ *
+ * **deprecated** This is no longer needed, prefers store the [KotlinCallable] in userdata directly.
+ */
+@InternalBinding
+@OptIn(ExperimentalAtomicApi::class)
+public object CallableUserdataMap {
+    private val map = mutableMapOf<Long, KotlinCallable>()
+    private var nextId = AtomicLong(0)
+
+    public fun add(callable: KotlinCallable): Long {
+        val id = nextId.incrementAndFetch()
+        map[id] = callable
+        return id
+    }
+
+    public fun remove(id: Long) {
+        map.remove(id)
+    }
+
+    public fun get(id: Long): KotlinCallable? = map[id]
+}

--- a/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/KotlinCallable.kt
+++ b/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/callback/KotlinCallable.kt
@@ -1,0 +1,50 @@
+package io.github.kingg22.godot.internal.callback
+
+/**
+ * Interface for Kotlin lambdas stored as callable userdata.
+ *
+ * This interface represents a Kotlin function that can be invoked by Godot's
+ * custom callable system. Each implementation holds a lambda and provides
+ * the necessary metadata (arity, hash, equality) for the callable infrastructure.
+ */
+public interface KotlinCallable {
+    /**
+     * Invokes this callable with the given arguments.
+     *
+     * @param args The arguments as Kotlin Any? array
+     * @return The result of the invocation, or null if no result
+     */
+    public fun call(args: Array<Any?>): Any?
+
+    /**
+     * Returns the number of arguments this callable expects.
+     */
+    public fun arity(): Int
+
+    /**
+     * Returns a hash value for this callable.
+     */
+    public fun hash(): Int
+
+    /**
+     * Checks equality with another KotlinCallable.
+     */
+    public fun equals(other: KotlinCallable): Boolean
+
+    /**
+     * Returns a string representation for debugging.
+     */
+    public override fun toString(): String
+
+    /**
+     * Returns whether this callable is still valid.
+     * Default implementation returns true.
+     */
+    public fun isValid(): Boolean = true
+
+    /**
+     * Comparison for less-than ordering (used for sorting/btrees).
+     * Default implementation returns false.
+     */
+    public fun lessThan(other: KotlinCallable): Boolean = false
+}

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/SpriteBench.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/SpriteBench.kt
@@ -16,18 +16,25 @@ import io.github.kingg22.godot.api.utils.GD
 import io.github.kingg22.godot.api.utils.print
 import io.github.kingg22.godot.binding.instantiate
 import io.github.kingg22.godot.castTo
+import io.github.kingg22.godot.internal.binding.InternalBinding
+import io.github.kingg22.godot.internal.callback.CallableFactory
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.ExperimentalForeignApi
 
 private const val FRAME_COUNT = 1_000
 private const val START_FRAME = 100
-private const val SPRITE_COUNT = 20_000
+private const val SPRITE_COUNT = 5
 
 @Godot class SpriteBench(nativePtr: COpaquePointer) : Node2D(nativePtr) {
     private val frameTimes = DoubleArray(FRAME_COUNT) { 0.0 }
     private var currentFrame = 0
     private var frameIndex = 0
     private var windowSize: Vector2 = Vector2.ZERO
+
+    @OptIn(InternalBinding::class)
+    private val callable = CallableFactory.create {
+        println("Hello from Kotlin inside a Callable!")
+    }
 
     init {
         GD.print("A new SpriteBench was created with pointer ${nativePtr.rawValue}")
@@ -76,6 +83,12 @@ private const val SPRITE_COUNT = 20_000
                 }
             }
             println("[SpriteBench] All $SPRITE_COUNT sprites added successfully")
+
+            println("[SpriteBench] _ready finished, going to call deferred callable")
+            val returnVariant = callable.call()
+            println(
+                "[SpriteBench] Callable returned: ${returnVariant.stringify().rawPtr}, is nil: ${returnVariant.isNil()}",
+            )
         } catch (e: Throwable) {
             println("[SpriteBench] === _ready failed ===")
             e.printStackTrace()


### PR DESCRIPTION
This is a base support and usage example with Callable0
First step of #56

## Summary by Sourcery

Agregar la infraestructura inicial para envolver lambdas de Kotlin como *Callables* de Godot y restringir el manejo y las conversiones de tipos de `Variant`.

Nuevas funcionalidades:
- Introducir un `CallableFactory` y la infraestructura de *callbacks* relacionada para crear *Callables* de Godot a partir de lambdas de Kotlin sin argumentos.
- Agregar un ejemplo de uso de *Callables* respaldados por Kotlin en la escena de ejemplo `SpriteBench`.

Mejoras:
- Refinar las utilidades de conversión de `Variant` con un conversor centralizado de `any` a `Variant` y comprobaciones de tipo en tiempo de ejecución más estrictas para `Variant.getValue` y el acceso a propiedades.
- Exponer los tipos `Variant` de los parámetros de señales mediante `SignalParameterDescriptor` y aplicar `@MustBeVariant` en las definiciones de parámetros de señales.
- Simplificar la lógica interna de emisión/conexión de señales para reutilizar tipos de `Variant` precomputados y patrones compartidos de manejo de errores.

Documentación:
- Documentar las limitaciones de seguridad y desaprobar los antiguos *helpers* de tipos `Variant` que no manejan correctamente la herencia de `GodotObject`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add initial infrastructure for wrapping Kotlin lambdas as Godot Callables and tighten Variant type handling and conversions.

New Features:
- Introduce a CallableFactory and related callback infrastructure to create Godot Callables from Kotlin zero-argument lambdas.
- Add an example usage of Kotlin-backed Callables in the SpriteBench sample scene.

Enhancements:
- Refine Variant conversion utilities with a centralized any-to-Variant converter and stricter runtime type checks for Variant getValue and property access.
- Expose signal parameter Variant types via SignalParameterDescriptor and enforce @MustBeVariant on signal parameter definitions.
- Simplify signal emission/connection internals to reuse precomputed Variant types and shared error-handling patterns.

Documentation:
- Document safety limitations and deprecate legacy Variant type helpers that do not handle GodotObject inheritance correctly.

</details>