### PR TITLE
fix(deps): update dependency com.palantir.javaformat:palantir-java-fo…

### DIFF
--- a/build-logic/src/main/kotlin/io/github/kingg22/buildlogic/java/JavaStylesConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/kingg22/buildlogic/java/JavaStylesConventionsPlugin.kt
@@ -13,7 +13,7 @@ class JavaStylesConventionsPlugin : Plugin<Project> {
             java {
                 removeUnusedImports()
                 // https://github.com/palantir/palantir-java-format/releases
-                palantirJavaFormat("2.89.0").formatJavadoc(false)
+                palantirJavaFormat("2.90.0").formatJavadoc(false)
                 importOrder("", "java", "javax", "\\#")
                 formatAnnotations()
             }


### PR DESCRIPTION
…rmat to v2.90.0

## Summary by Sourcery

Build:
- Actualizar la configuración de Gradle de Palantir Java Format de la versión 2.89.0 a la 2.90.0.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Bump Palantir Java Format Gradle configuration from version 2.89.0 to 2.90.0.

</details>