### PR TITLE
feat(binding): add wip signal binding and register

### DIFF
--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/ImplementationPackageRegistry.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/ImplementationPackageRegistry.kt
@@ -49,6 +49,7 @@ class ImplementationPackageRegistry(packageStr: String, interfaceModel: GDExtens
         put("GDExtensionPtrBuiltInMethod", ffiPackage)
         put("GDExtensionMethodBindPtr", ffiPackage)
         put("GDExtensionPtrOperatorEvaluator", ffiPackage)
+        put("GDExtensionObjectPtrVar", ffiPackage)
         put("checkGodotError", apiInternalPackage)
         put("CallableFactory", "$apiInternalPackage.callable")
     }

--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VariantImplGen.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VariantImplGen.kt
@@ -222,6 +222,28 @@ class VariantImplGen(private val typeResolver: TypeResolver) {
                 .build(),
         )
 
+        classBuilder.addFunction(
+            FunSpec
+                .constructorBuilder()
+                .addParameter("value", ctx.classNameForOrDefault("Object"))
+                .callThisConstructor()
+                .addCode(
+                    CodeBlock
+                        .builder()
+                        .beginControlFlow("%M", memScoped)
+                        .addStatement(
+                            "val objPtr = %M<%T>()",
+                            cinteropAlloc,
+                            implPackageRegistry.classNameForOrDefault("GDExtensionObjectPtrVar"),
+                        )
+                        .addStatement("objPtr.%M = value.rawPtr", cinteropValue)
+                        .addStatement("fromTypeFptr_%L.%M(rawPtr, objPtr.%M)", "OBJECT", cinteropInvoke, cinteropPtr)
+                        .endControlFlow()
+                        .build(),
+                )
+                .build(),
+        )
+
         // All builtin/object types — value.rawPtr path
         variantTypes.raw.values.forEach { enumValue ->
             val (valueType, subclassName) = resolveTypeNameAndName(enumValue) ?: return@forEach
@@ -1143,7 +1165,7 @@ class VariantImplGen(private val typeResolver: TypeResolver) {
     context(ctx: Context)
     private fun resolveTypeNameAndName(
         enumValue: EnumConstant,
-        filter: (String) -> Boolean = { it == "BOOL" || it == "INT" || it == "FLOAT" },
+        filter: (String) -> Boolean = { it == "BOOL" || it == "INT" || it == "FLOAT" || it == "OBJECT" },
     ): Pair<TypeName, String>? {
         val subclassName = enumValue.name.removePrefix("TYPE_")
             .takeUnless { it == "MAX" || it == "NIL" || filter(it) }

--- a/kotlin-native/api/annotations/src/nativeMain/kotlin/io/github/kingg22/godot/api/annotations/RegisterSignal.kt
+++ b/kotlin-native/api/annotations/src/nativeMain/kotlin/io/github/kingg22/godot/api/annotations/RegisterSignal.kt
@@ -1,0 +1,26 @@
+package io.github.kingg22.godot.api.annotations
+
+import io.github.kingg22.godot.api.builtin.Variant
+import io.github.kingg22.godot.api.global.PropertyHint
+import io.github.kingg22.godot.api.global.PropertyUsageFlags
+
+/**
+ * Requires to be annotated in a property of [io.github.kingg22.godot.api.builtin.Signal]
+ * @param name The signal name. If empty, the property name is used.
+ * @param params The signal parameters. Must be used in the same order to connect to the signal.
+ * @see io.github.kingg22.godot.api.builtin.Signal
+ */
+@Retention(SOURCE)
+@Target(PROPERTY)
+public annotation class RegisterSignal(vararg val params: Param = [], val name: String = "") {
+
+    @Retention(SOURCE)
+    @Target()
+    public annotation class Param(
+        val type: Variant.Type,
+        val name: String,
+        val hints: Array<PropertyHint> = [],
+        val hintString: String = "",
+        val usages: Array<PropertyUsageFlags> = [],
+    )
+}

--- a/kotlin-native/api/callable/build.gradle.kts
+++ b/kotlin-native/api/callable/build.gradle.kts
@@ -1,0 +1,37 @@
+import io.github.kingg22.buildlogic.godot.conventions.CodegenBackend
+import io.github.kingg22.buildlogic.godot.conventions.CodegenKind
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform.conventions)
+    alias(libs.plugins.kotlin.styles.conventions)
+    alias(libs.plugins.godot.codegen.simple)
+    alias(libs.plugins.dokka.conventions)
+}
+
+kotlin {
+    explicitApi()
+    compilerOptions {
+        optIn.addAll(
+            "kotlinx.cinterop.ExperimentalForeignApi",
+            "kotlin.experimental.ExperimentalNativeApi",
+        )
+    }
+
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    dependencies {
+        implementation(projects.kotlinNative.runtime)
+        implementation(projects.kotlinNative.api.chore)
+    }
+
+    applyDefaultHierarchyTemplate()
+
+    linuxX64()
+    // mingwX64()
+}
+
+godotCodegen {
+    backend = CodegenBackend.KOTLIN_NATIVE
+    kind = CodegenKind.CALLABLE
+    packageName = "io.github.kingg22.godot.api.internal.callable"
+}

--- a/kotlin-native/api/callable/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableBinding.kt
+++ b/kotlin-native/api/callable/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableBinding.kt
@@ -1,0 +1,54 @@
+package io.github.kingg22.godot.api.internal.callable
+
+import io.github.kingg22.godot.internal.binding.BindingProcAddressHolder
+import io.github.kingg22.godot.internal.binding.CallableBinding
+import io.github.kingg22.godot.internal.binding.InternalBinding
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomCall
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomInfo2
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.cValue
+import kotlinx.cinterop.memScoped
+
+@InternalBinding
+public object CallableBinding {
+
+    // Call the low-level Godot function to create custom callable and fill the callable object
+    public fun createCustom(callableCustomInfo2: CValue<GDExtensionCallableCustomInfo2>, callablePtr: COpaquePointer) {
+        memScoped {
+            CallableBinding.instance.customCreate2Raw(
+                callablePtr,
+                callableCustomInfo2.ptr,
+            )
+        }
+    }
+
+    public fun storeKotlinCallable(lambda: Function<*>): COpaquePointer =
+        StableRef.create(wrapLambda(lambda)).asCPointer()
+
+    /**
+     * Creates a [GDExtensionCallableCustomInfo2] struct.
+     * Delegates to [CallableTrampolines]
+     * @param userdata Expects a [KotlinCallable] as [COpaquePointer]
+     * @param call The custom function to call this callable
+     * @param objectId 0 means _custom_, not bind to object
+     */
+    public fun createCallableCustomInfo2(
+        userdata: COpaquePointer,
+        call: GDExtensionCallableCustomCall,
+        objectId: ULong = 0uL,
+    ): CValue<GDExtensionCallableCustomInfo2> = cValue {
+        object_id = objectId
+        callable_userdata = userdata
+        call_func = call
+        token = BindingProcAddressHolder.library
+        is_valid_func = CallableTrampolines.isValidFunc
+        free_func = CallableTrampolines.freeFunc
+        hash_func = CallableTrampolines.hashFunc
+        equal_func = CallableTrampolines.equalFunc
+        less_than_func = CallableTrampolines.lessThanFunc
+        to_string_func = CallableTrampolines.toStringFunc
+        get_argument_count_func = CallableTrampolines.getArgumentCountFunc
+    }
+}

--- a/kotlin-native/api/callable/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableBinding.kt
+++ b/kotlin-native/api/callable/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableBinding.kt
@@ -1,21 +1,120 @@
 package io.github.kingg22.godot.api.internal.callable
 
+import io.github.kingg22.godot.api.GodotNative
 import io.github.kingg22.godot.internal.binding.BindingProcAddressHolder
 import io.github.kingg22.godot.internal.binding.CallableBinding
 import io.github.kingg22.godot.internal.binding.InternalBinding
+import io.github.kingg22.godot.internal.binding.VariantBinding
+import io.github.kingg22.godot.internal.binding.getInstance
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallError
+import io.github.kingg22.godot.internal.ffi.GDExtensionCallErrorType
 import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomCall
 import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomInfo2
-import kotlinx.cinterop.COpaquePointer
-import kotlinx.cinterop.CValue
-import kotlinx.cinterop.StableRef
-import kotlinx.cinterop.cValue
-import kotlinx.cinterop.memScoped
+import io.github.kingg22.godot.internal.ffi.GDExtensionConstVariantPtr
+import io.github.kingg22.godot.internal.ffi.GDExtensionConstVariantPtrVar
+import io.github.kingg22.godot.internal.ffi.GDExtensionInt
+import io.github.kingg22.godot.internal.ffi.GDExtensionVariantPtr
+import kotlinx.cinterop.*
 
+/**
+ * This is a low-level binding for custom callables. You must use `CallabeFactory` to create custom callables or use the `Callable` class.
+ *
+ * The initialization of `CallableFactory` link properties of this class. Must not be invoked before that happens,
+ * otherwise the binding throws errors with null values.
+ *
+ * Currently missing correct support to convert arguments to kotlin types. So must use `Any?` or exact `Variant` types,
+ * `Variant` itself as argument is not supported.
+ *
+ * Currently, all callables are `static` for Godot, missing linking to the object. This can lead to incorrect freeing.
+ */
 @InternalBinding
 public object CallableBinding {
+    public var onError: (message: String) -> Unit = ::println
+    public var onVariantToKotlin: (GDExtensionConstVariantPtr?) -> Any? = { null }
+    public var onToVariant: (Any?) -> GodotNative? = { null }
+
+    // Create the GDExtensionCallableCustomInfo2 struct using cValue
+    public fun createCustomInfo2(lambda: Function<*>, objectId: ULong = 0uL): CValue<GDExtensionCallableCustomInfo2> =
+        createCustomInfo2(
+            // Create a KotlinCallable wrapper and store it in a StableRef on userdata
+            storeKotlinFunctionAsKotlinCallable(lambda),
+            createCustomCall(),
+            objectId,
+        )
+
+    public fun createCustomCall(): GDExtensionCallableCustomCall = staticCFunction {
+            userdata: COpaquePointer?,
+            arguments: CArrayPointer<GDExtensionConstVariantPtrVar>?,
+            argumentCount: GDExtensionInt,
+            rReturn: GDExtensionVariantPtr?,
+            rError: CPointer<GDExtensionCallError>?,
+        ->
+        val callable = userdata?.getInstance<KotlinCallable>()
+
+        if (callable == null || rReturn == null || rError == null) {
+            onError(
+                "Invalid arguments received from Godot to Callable custom call: $arguments, $argumentCount, $rReturn, $rError, $userdata == $callable",
+            )
+            return@staticCFunction
+        }
+
+        fun fillCallError(
+            error: GDExtensionCallErrorType,
+            expected: Int = callable.arity().toInt(),
+            argument: Int = argumentCount.toInt(),
+        ) {
+            val callError = rError.pointed
+            callError.error = error
+            callError.expected = expected
+            callError.argument = argument
+        }
+
+        if (argumentCount != callable.arity()) {
+            onError("[kogot]: Error: callable called with $argumentCount arguments, expected ${callable.arity()}")
+            fillCallError(
+                if (argumentCount < callable.arity()) {
+                    GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS
+                } else {
+                    GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS
+                },
+            )
+            return@staticCFunction
+        }
+
+        if (argumentCount != 0L && arguments == null) {
+            onError("[kogot]: Error: callable called with null array of arguments, expected $argumentCount")
+            fillCallError(GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT)
+            return@staticCFunction
+        }
+
+        // FIXME validate arguments order is preserved
+        val arguments = Array(argumentCount.toInt()) { i ->
+            // FIXME requires apropiate conversion to Kotlin types. Requires supports downcast, Variant, KString
+            onVariantToKotlin(arguments?.get(i))
+        }
+
+        val result: Any? = runCatching { callable.invoke(arguments) }.getOrElse { exception ->
+            onError(
+                "[kogot]: Error calling callable ${callable.arity()} args, fallback to null: $exception",
+            )
+            fillCallError(GDEXTENSION_CALL_ERROR_INVALID_METHOD)
+            return@staticCFunction
+        }
+
+        // TODO: properly convert return types to Kotlin types
+        // (aka if the user request T, the argument must preserve the type T, not unbox or box unrequested)
+        val resultVariant = onToVariant(result) ?: run {
+            onError("[kogot]: Error converting callable result ($result) to Variant, fallback to null")
+            fillCallError(GDEXTENSION_CALL_ERROR_INVALID_METHOD)
+            return@staticCFunction
+        }
+
+        fillCallError(GDEXTENSION_CALL_OK, 0, 0)
+        VariantBinding.instance.newCopyRaw(rReturn, resultVariant.rawPtr)
+    }
 
     // Call the low-level Godot function to create custom callable and fill the callable object
-    public fun createCustom(callableCustomInfo2: CValue<GDExtensionCallableCustomInfo2>, callablePtr: COpaquePointer) {
+    public fun createCustom2(callableCustomInfo2: CValue<GDExtensionCallableCustomInfo2>, callablePtr: COpaquePointer) {
         memScoped {
             CallableBinding.instance.customCreate2Raw(
                 callablePtr,
@@ -24,7 +123,8 @@ public object CallableBinding {
         }
     }
 
-    public fun storeKotlinCallable(lambda: Function<*>): COpaquePointer =
+    /** Wraps a [Kotlin function][Function] into a [KotlinCallable] using [StableRef] */
+    public fun storeKotlinFunctionAsKotlinCallable(lambda: Function<*>): COpaquePointer =
         StableRef.create(wrapLambda(lambda)).asCPointer()
 
     /**
@@ -34,7 +134,7 @@ public object CallableBinding {
      * @param call The custom function to call this callable
      * @param objectId 0 means _custom_, not bind to object
      */
-    public fun createCallableCustomInfo2(
+    public fun createCustomInfo2(
         userdata: COpaquePointer,
         call: GDExtensionCallableCustomCall,
         objectId: ULong = 0uL,

--- a/kotlin-native/api/callable/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableTrampolines.kt
+++ b/kotlin-native/api/callable/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableTrampolines.kt
@@ -3,16 +3,7 @@ package io.github.kingg22.godot.api.internal.callable
 import io.github.kingg22.godot.internal.binding.InternalBinding
 import io.github.kingg22.godot.internal.binding.StringBinding
 import io.github.kingg22.godot.internal.binding.getInstance
-import io.github.kingg22.godot.internal.ffi.FALSE
-import io.github.kingg22.godot.internal.ffi.GDExtensionBool
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomEqual
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomFree
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomGetArgumentCount
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomHash
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomIsValid
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomLessThan
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomToString
-import io.github.kingg22.godot.internal.ffi.TRUE
+import io.github.kingg22.godot.internal.ffi.*
 import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.set
 import kotlinx.cinterop.staticCFunction
@@ -32,8 +23,9 @@ public object CallableTrampolines {
      * Cleans up the userdata from the map.
      */
     public val freeFunc: GDExtensionCallableCustomFree = staticCFunction { userdata ->
-        val ref = requireNotNull(userdata).asStableRef<KotlinCallable>()
-        ref.dispose()
+        println("Freeing callable with userdata: $userdata")
+        val ref = userdata?.asStableRef<KotlinCallable>()
+        ref?.dispose()
     }
 
     /**

--- a/kotlin-native/api/callable/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/KotlinCallable.kt
+++ b/kotlin-native/api/callable/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/KotlinCallable.kt
@@ -12,9 +12,7 @@ import io.github.kingg22.godot.internal.binding.InternalBinding
  *
  * This is similar to the [Function] interface in the Kotlin standard library.
  *
- * @see CallableFactory
  * @see CallableTrampolines
- * @see Function
  */
 @UsedFromCodegenGeneratedCode
 @InternalBinding

--- a/kotlin-native/api/chore/src/nativeMain/kotlin/io/github/kingg22/godot/api/EnumMask.kt
+++ b/kotlin-native/api/chore/src/nativeMain/kotlin/io/github/kingg22/godot/api/EnumMask.kt
@@ -63,7 +63,10 @@ public value class EnumMask<T> @ExperimentalGodotKotlin constructor(public val f
             EnumMask(first.value or second.value)
 
         /** Creates a mask from multiple enums */
-        public inline fun <T> of(vararg flags: T): EnumMask<T> where T : GodotEnum, T : Enum<T> =
+        public inline fun <T> of(vararg flags: T): EnumMask<T> where T : GodotEnum, T : Enum<T> = of(flags.toList())
+
+        /** Creates a mask from multiple enums */
+        public inline fun <T> of(flags: Iterable<T>): EnumMask<T> where T : GodotEnum, T : Enum<T> =
             EnumMask(flags.fold(0L) { acc, flag -> acc or flag.value })
     }
 }
@@ -86,3 +89,9 @@ public inline infix fun <T> T.or(other: T): EnumMask<T> where T : GodotEnum, T :
  */
 public inline infix fun <T> T.or(mask: EnumMask<T>): EnumMask<T> where T : GodotEnum, T : Enum<T> =
     EnumMask(this.value or mask.flags)
+
+/** Converts [Array] of [enums][GodotEnum] to an [EnumMask] of the same type */
+public inline fun <T> Array<T>.toEnumMask(): EnumMask<T> where T : GodotEnum, T : Enum<T> = EnumMask.of(this.toList())
+
+/** Converts [Iterable] of [enums][GodotEnum] to an [EnumMask] of the same type */
+public inline fun <T> Iterable<T>.toEnumMask(): EnumMask<T> where T : GodotEnum, T : Enum<T> = EnumMask.of(this)

--- a/kotlin-native/api/generated/build.gradle.kts
+++ b/kotlin-native/api/generated/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
     dependencies {
         api(projects.kotlinNative.runtime)
         api(projects.kotlinNative.api.chore)
+        api(projects.kotlinNative.api.callable)
     }
 
     applyDefaultHierarchyTemplate()
@@ -47,12 +48,4 @@ godotCodegen {
     backend = CodegenBackend.KOTLIN_NATIVE
     kind = CodegenKind.API
     packageName = "io.github.kingg22.godot"
-
-    combinations {
-        register("callable") {
-            backend = CodegenBackend.KOTLIN_NATIVE
-            kind = CodegenKind.CALLABLE
-            packageName = "io.github.kingg22.godot.api.internal.callable"
-        }
-    }
 }

--- a/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/core/Alias.kt
+++ b/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/core/Alias.kt
@@ -1,0 +1,5 @@
+@file:Suppress("ktlint:standard:filename") // Maintain as Alias to add more typealias in the future
+
+package io.github.kingg22.godot.api.core
+
+public typealias Object = GodotObject

--- a/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableFactory.kt
+++ b/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableFactory.kt
@@ -5,25 +5,21 @@ import io.github.kingg22.godot.api.builtin.Variant
 import io.github.kingg22.godot.api.builtin.internal.anyToVariantOrNull
 import io.github.kingg22.godot.api.builtin.internal.getValue
 import io.github.kingg22.godot.api.internal.UsedFromCodegenGeneratedCode
+import io.github.kingg22.godot.api.internal.callable.CallableBinding.createCallableCustomInfo2
+import io.github.kingg22.godot.api.internal.callable.CallableBinding.createCustom
+import io.github.kingg22.godot.api.internal.callable.CallableBinding.storeKotlinCallable
 import io.github.kingg22.godot.api.utils.GD
 import io.github.kingg22.godot.api.utils.pushError
-import io.github.kingg22.godot.internal.binding.BindingProcAddressHolder
-import io.github.kingg22.godot.internal.binding.CallableBinding
 import io.github.kingg22.godot.internal.binding.InternalBinding
 import io.github.kingg22.godot.internal.binding.VariantBinding
 import io.github.kingg22.godot.internal.binding.getInstance
 import io.github.kingg22.godot.internal.ffi.GDExtensionCallErrorType
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomCall
 import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomInfo2
 import io.github.kingg22.godot.internal.ffi.GDExtensionConstVariantPtr
 import io.github.kingg22.godot.internal.ffi.GDExtensionConstVariantPtrVar
 import kotlinx.cinterop.CArrayPointer
-import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.CValue
-import kotlinx.cinterop.StableRef
-import kotlinx.cinterop.cValue
 import kotlinx.cinterop.get
-import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.pointed
 import kotlinx.cinterop.staticCFunction
 
@@ -44,13 +40,7 @@ public object CallableFactory {
     public fun create(lambda: Function<*>, callable: Callable) {
         check(callable.isNull()) { "Callable must be null to create a custom callable" }
         val callableCustomInfo2 = createImpl(lambda)
-        // Call the low-level Godot function to create custom callable and fill the callable object
-        memScoped {
-            CallableBinding.instance.customCreate2Raw(
-                callable.rawPtr,
-                callableCustomInfo2.ptr,
-            )
-        }
+        createCustom(callableCustomInfo2, callable.rawPtr)
     }
 
     /** See [Callable] class and factory function. Create the empty Callable */
@@ -136,34 +126,6 @@ public object CallableFactory {
         },
     )
 
-    public fun storeKotlinCallable(lambda: Function<*>): COpaquePointer =
-        StableRef.create(wrapLambda(lambda)).asCPointer()
-
     public fun reinterpretedVariantToKotlin(argument: GDExtensionConstVariantPtr?): Any? =
         if (argument == null) null else Variant(argument).getValue()
-
-    /**
-     * Creates a [GDExtensionCallableCustomInfo2] struct.
-     * Delegates to [CallableTrampolines]
-     * @param userdata Expects a [KotlinCallable] as [COpaquePointer]
-     * @param call The custom function to call this callable
-     * @param objectId 0 means _custom_, not bind to object
-     */
-    public fun createCallableCustomInfo2(
-        userdata: COpaquePointer,
-        call: GDExtensionCallableCustomCall,
-        objectId: ULong = 0uL,
-    ): CValue<GDExtensionCallableCustomInfo2> = cValue {
-        object_id = objectId
-        callable_userdata = userdata
-        call_func = call
-        token = BindingProcAddressHolder.library
-        is_valid_func = CallableTrampolines.isValidFunc
-        free_func = CallableTrampolines.freeFunc
-        hash_func = CallableTrampolines.hashFunc
-        equal_func = CallableTrampolines.equalFunc
-        less_than_func = CallableTrampolines.lessThanFunc
-        to_string_func = CallableTrampolines.toStringFunc
-        get_argument_count_func = CallableTrampolines.getArgumentCountFunc
-    }
 }

--- a/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableFactory.kt
+++ b/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableFactory.kt
@@ -5,23 +5,10 @@ import io.github.kingg22.godot.api.builtin.Variant
 import io.github.kingg22.godot.api.builtin.internal.anyToVariantOrNull
 import io.github.kingg22.godot.api.builtin.internal.getValue
 import io.github.kingg22.godot.api.internal.UsedFromCodegenGeneratedCode
-import io.github.kingg22.godot.api.internal.callable.CallableBinding.createCallableCustomInfo2
-import io.github.kingg22.godot.api.internal.callable.CallableBinding.createCustom
-import io.github.kingg22.godot.api.internal.callable.CallableBinding.storeKotlinCallable
 import io.github.kingg22.godot.api.utils.GD
 import io.github.kingg22.godot.api.utils.pushError
 import io.github.kingg22.godot.internal.binding.InternalBinding
-import io.github.kingg22.godot.internal.binding.VariantBinding
-import io.github.kingg22.godot.internal.binding.getInstance
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallErrorType
-import io.github.kingg22.godot.internal.ffi.GDExtensionCallableCustomInfo2
 import io.github.kingg22.godot.internal.ffi.GDExtensionConstVariantPtr
-import io.github.kingg22.godot.internal.ffi.GDExtensionConstVariantPtrVar
-import kotlinx.cinterop.CArrayPointer
-import kotlinx.cinterop.CValue
-import kotlinx.cinterop.get
-import kotlinx.cinterop.pointed
-import kotlinx.cinterop.staticCFunction
 
 /**
  * Factory for creating Godot custom Callables from Kotlin lambdas.
@@ -35,96 +22,22 @@ import kotlinx.cinterop.staticCFunction
 @UsedFromCodegenGeneratedCode
 @InternalBinding
 public object CallableFactory {
+    init {
+        CallableBinding.onError = GD::pushError
+        CallableBinding.onVariantToKotlin = ::reinterpretedVariantToKotlin
+        CallableBinding.onToVariant = ::anyToVariantOrNull
+    }
+
     /** See [Callable] class and factory function */
     @UsedFromCodegenGeneratedCode
     public fun create(lambda: Function<*>, callable: Callable) {
         check(callable.isNull()) { "Callable must be null to create a custom callable" }
-        val callableCustomInfo2 = createImpl(lambda)
-        createCustom(callableCustomInfo2, callable.rawPtr)
+        val callableCustomInfo2 = CallableBinding.createCustomInfo2(lambda)
+        CallableBinding.createCustom2(callableCustomInfo2, callable.rawPtr)
     }
 
     /** See [Callable] class and factory function. Create the empty Callable */
     public fun create(lambda: Function<*>): Callable = Callable(null).apply { create(lambda, this) }
-
-    // Create the GDExtensionCallableCustomInfo2 struct using cValue
-    public fun createImpl(lambda: Function<*>): CValue<GDExtensionCallableCustomInfo2> = createCallableCustomInfo2(
-        // Create a KotlinCallable wrapper and store it in a StableRef on userdata
-        storeKotlinCallable(lambda),
-        staticCFunction {
-                userdata,
-                arguments: CArrayPointer<GDExtensionConstVariantPtrVar>?,
-                argumentCount,
-                rReturn,
-                rError,
-            ->
-            val callable = userdata?.getInstance<KotlinCallable>()
-
-            if (callable == null || rReturn == null || rError == null) {
-                GD.pushError(
-                    "Invalid arguments received from Godot to Callable custom call: $arguments, $argumentCount, $rReturn, $rError, $userdata == $callable",
-                )
-                return@staticCFunction
-            }
-
-            fun fillCallError(
-                error: GDExtensionCallErrorType,
-                expected: Int = callable.arity().toInt(),
-                argument: Int = argumentCount.toInt(),
-            ) {
-                val callError = rError.pointed
-                callError.error = error
-                callError.expected = expected
-                callError.argument = argument
-            }
-
-            if (argumentCount != callable.arity()) {
-                GD.pushError(
-                    "[kogot]: Error: callable called with $argumentCount arguments, expected ${callable.arity()}",
-                )
-                fillCallError(
-                    if (argumentCount < callable.arity()) {
-                        GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS
-                    } else {
-                        GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS
-                    },
-                )
-                return@staticCFunction
-            }
-
-            if (argumentCount != 0L && arguments == null) {
-                GD.pushError(
-                    "[kogot]: Error: callable called with null array of arguments, expected $argumentCount",
-                )
-                fillCallError(GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT)
-                return@staticCFunction
-            }
-
-            // FIXME validate arguments order is preserved
-            val arguments = Array(argumentCount.toInt()) { i ->
-                // FIXME requires apropiate conversion to Kotlin types. Requires supports downcast, Variant, KString
-                reinterpretedVariantToKotlin(arguments?.get(i))
-            }
-
-            val result: Any? = runCatching { callable.invoke(arguments) }.getOrElse { exception ->
-                GD.pushError(
-                    "[kogot]: Error calling callable ${callable.arity()} args, fallback to null: $exception",
-                )
-                fillCallError(GDEXTENSION_CALL_ERROR_INVALID_METHOD)
-                return@staticCFunction
-            }
-
-            // TODO: properly convert return types to Kotlin types
-            // (aka if the user request T, the argument must preserve the type T, not unbox or box unrequested)
-            val resultVariant = anyToVariantOrNull(result) ?: run {
-                GD.pushError("[kogot]: Error converting callable result ($result) to Variant, fallback to null")
-                fillCallError(GDEXTENSION_CALL_ERROR_INVALID_METHOD)
-                return@staticCFunction
-            }
-
-            fillCallError(GDEXTENSION_CALL_OK, 0, 0)
-            VariantBinding.instance.newCopyRaw(rReturn, resultVariant.rawPtr)
-        },
-    )
 
     public fun reinterpretedVariantToKotlin(argument: GDExtensionConstVariantPtr?): Any? =
         if (argument == null) null else Variant(argument).getValue()

--- a/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableFactory.kt
+++ b/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableFactory.kt
@@ -54,7 +54,7 @@ public object CallableFactory {
     }
 
     /** See [Callable] class and factory function. Create the empty Callable */
-    public fun create(lambda: Function<*>): Callable = Callable().apply { create(lambda, this) }
+    public fun create(lambda: Function<*>): Callable = Callable(null).apply { create(lambda, this) }
 
     // Create the GDExtensionCallableCustomInfo2 struct using cValue
     public fun createImpl(lambda: Function<*>): CValue<GDExtensionCallableCustomInfo2> = createCallableCustomInfo2(

--- a/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableFactory.kt
+++ b/kotlin-native/api/generated/src/nativeMain/kotlin/io/github/kingg22/godot/api/internal/callable/CallableFactory.kt
@@ -2,7 +2,7 @@ package io.github.kingg22.godot.api.internal.callable
 
 import io.github.kingg22.godot.api.builtin.Callable
 import io.github.kingg22.godot.api.builtin.Variant
-import io.github.kingg22.godot.api.builtin.internal.anyToVariant
+import io.github.kingg22.godot.api.builtin.internal.anyToVariantOrNull
 import io.github.kingg22.godot.api.builtin.internal.getValue
 import io.github.kingg22.godot.api.internal.UsedFromCodegenGeneratedCode
 import io.github.kingg22.godot.api.utils.GD
@@ -76,11 +76,15 @@ public object CallableFactory {
                 return@staticCFunction
             }
 
-            fun fillCallError(error: GDExtensionCallErrorType) {
+            fun fillCallError(
+                error: GDExtensionCallErrorType,
+                expected: Int = callable.arity().toInt(),
+                argument: Int = argumentCount.toInt(),
+            ) {
                 val callError = rError.pointed
                 callError.error = error
-                callError.expected = callable.arity().toInt()
-                callError.argument = argumentCount.toInt()
+                callError.expected = expected
+                callError.argument = argument
             }
 
             if (argumentCount != callable.arity()) {
@@ -121,14 +125,13 @@ public object CallableFactory {
 
             // TODO: properly convert return types to Kotlin types
             // (aka if the user request T, the argument must preserve the type T, not unbox or box unrequested)
-            val resultVariant = runCatching { anyToVariant(result) }.getOrElse { exception ->
-                GD.pushError(
-                    "[kogot]: Error converting callable result ($result) to Variant, fallback to null: $exception",
-                )
+            val resultVariant = anyToVariantOrNull(result) ?: run {
+                GD.pushError("[kogot]: Error converting callable result ($result) to Variant, fallback to null")
                 fillCallError(GDEXTENSION_CALL_ERROR_INVALID_METHOD)
                 return@staticCFunction
             }
 
+            fillCallError(GDEXTENSION_CALL_OK, 0, 0)
             VariantBinding.instance.newCopyRaw(rReturn, resultVariant.rawPtr)
         },
     )

--- a/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/binding/SignalRegistration.kt
+++ b/kotlin-native/binding/src/nativeMain/kotlin/io/github/kingg22/godot/internal/binding/SignalRegistration.kt
@@ -1,0 +1,35 @@
+package io.github.kingg22.godot.internal.binding
+
+import io.github.kingg22.godot.api.annotations.RegisterSignal
+import io.github.kingg22.godot.api.builtin.asStringName
+import io.github.kingg22.godot.api.builtin.internal.toGDE
+import io.github.kingg22.godot.api.toEnumMask
+import io.github.kingg22.godot.internal.ffi.GDExtensionPropertyInfo
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+
+@InternalBinding
+public fun registerCustomSignal(className: String, signal: RegisterSignal) {
+    className.asStringName().use { className ->
+        signal.name.asStringName().use { signalName ->
+            memScoped {
+                val argumentsInfo = allocArray<GDExtensionPropertyInfo>(signal.params.size) { index ->
+                    val param = signal.params[index]
+                    this.type = param.type.toGDE()
+                    this.name = param.name.asStringName().rawPtr
+                    this.class_name = className.rawPtr
+                    this.hint = param.hints.toEnumMask().value.toUInt()
+                    this.hint_string = param.hintString.asStringName().rawPtr
+                    this.usage = param.usages.toEnumMask().value.toUInt()
+                }
+                ClassDBBinding.instance.registerExtensionClassSignalRaw(
+                    BindingProcAddressHolder.library,
+                    className.rawPtr,
+                    signalName.rawPtr,
+                    argumentsInfo,
+                    signal.params.size.toLong(),
+                )
+            }
+        }
+    }
+}

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/SpriteBench.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/SpriteBench.kt
@@ -9,7 +9,7 @@ import io.github.kingg22.godot.api.builtin.StringName
 import io.github.kingg22.godot.api.builtin.Variant
 import io.github.kingg22.godot.api.builtin.asStringName
 import io.github.kingg22.godot.api.builtin.asVariant
-import io.github.kingg22.godot.api.core.GodotObject
+import io.github.kingg22.godot.api.core.Object
 import io.github.kingg22.godot.api.core.node.Node2D
 import io.github.kingg22.godot.api.global.GodotError
 import io.github.kingg22.godot.internal.binding.ClassDBBinding
@@ -69,30 +69,31 @@ import kotlinx.cinterop.value
             println("connect punch result: $result : ${GodotEnum.fromValue<GodotError>(result)}")
         }
 
-        // ✅ emit usando Signal directamente
         try {
             println("[SpriteBench] emitting **hint** via Signal.emit fixed")
             val error = hint.emitFix()
-            println("emitSignalFix hint returned: $error")
+            println("emitFix hint returned: $error")
 
             println("[SpriteBench] emitting **punch** via Signal.emit fixed")
-            val error2 = punch.emitFix(12.asVariant())
-            println("emitSignalFix punch returned: $error2")
+            val error2 = punch.emitFix(12L.asVariant())
+            println("emitFix punch returned: $error2")
 
-            /* ✅ emit usando Object.emitSignal FIX
-            println("[SpriteBench] emitting punch via emitSignalFix")
-            val err = emitSignalFix(punchStr, 200.asVariant())
-            println("emitSignalFix punch returned: $err")
-             */
+            println("[SpriteBench] emitting **hint** via emitSignal")
+            val result = emitSignalFix(hintStr)
+            println("emitSignal hint result: $result")
+            println("[SpriteBench] emitting **punch** via emitSignal")
+            val result2 = emitSignalFix(punchStr, 15L.asVariant())
+            println("emitSignal punch result2: $result2")
         } catch (e: Exception) {
-            println("emitSignalFix failed: ${e.message}")
+            println("[SpriteBench] failed: ${e.message}")
+            e.printStackTrace()
         } finally {
             println("[SpriteBench] _ready finished")
         }
     }
 }
 
-fun signalFix(obj: GodotObject, signal: StringName) = Signal(null).apply {
+fun signalFix(obj: Object, signal: StringName) = Signal(null).apply {
     memScoped {
         val objectPtr = alloc<GDExtensionObjectPtrVar>()
         objectPtr.`value` = obj.rawPtr
@@ -130,20 +131,20 @@ private val methodSignalEmit_3286317445_Fn: GDExtensionPtrBuiltInMethod by lazy(
 }
 
 // **have errors**
-fun GodotObject.emitSignalFix(signal: StringName, vararg args: Variant): GodotError = memScoped {
-    val retPtr = alloc<LongVar>()
+fun Object.emitSignalFix(signal: StringName, vararg args: Variant): GodotError = memScoped {
+    val retPtr = Variant()
 
     val callError = ObjectBinding.instance.methodBindCall(
         methodObjectEmitSignal_Bind,
         rawPtr,
         signal.asVariant().rawPtr,
         *args.map { it.rawPtr }.toTypedArray(),
-        rRet = retPtr.ptr,
+        rRet = retPtr.rawPtr,
     )
 
     checkCallError("emitSignal of $signal", callError)
 
-    return GodotEnum.fromValue(retPtr.value)
+    return GodotEnum.fromValue(retPtr.asInt())
 }
 
 private val methodObjectEmitSignal_Bind: GDExtensionMethodBindPtr by lazy(PUBLICATION) {

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/SpriteBench.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/SpriteBench.kt
@@ -1,138 +1,156 @@
 @file:OptIn(ExperimentalForeignApi::class)
 
+import io.github.kingg22.godot.api.GodotEnum
 import io.github.kingg22.godot.api.annotations.Godot
+import io.github.kingg22.godot.api.annotations.RegisterSignal
 import io.github.kingg22.godot.api.builtin.Callable
-import io.github.kingg22.godot.api.builtin.Vector2
-import io.github.kingg22.godot.api.builtin.Vector2i
-import io.github.kingg22.godot.api.builtin.asGodotString
+import io.github.kingg22.godot.api.builtin.Signal
+import io.github.kingg22.godot.api.builtin.StringName
+import io.github.kingg22.godot.api.builtin.Variant
+import io.github.kingg22.godot.api.builtin.asStringName
 import io.github.kingg22.godot.api.builtin.asVariant
-import io.github.kingg22.godot.api.core.Node
-import io.github.kingg22.godot.api.core.SceneTree
+import io.github.kingg22.godot.api.core.GodotObject
 import io.github.kingg22.godot.api.core.node.Node2D
-import io.github.kingg22.godot.api.core.node.TextEdit
-import io.github.kingg22.godot.api.core.node.Window
-import io.github.kingg22.godot.api.core.refcounted.Texture2D
-import io.github.kingg22.godot.api.singleton.Engine
-import io.github.kingg22.godot.api.singleton.ResourceLoader
-import io.github.kingg22.godot.api.utils.GD
-import io.github.kingg22.godot.api.utils.print
-import io.github.kingg22.godot.binding.instantiate
-import io.github.kingg22.godot.castTo
+import io.github.kingg22.godot.api.global.GodotError
+import io.github.kingg22.godot.internal.binding.ClassDBBinding
+import io.github.kingg22.godot.internal.binding.ObjectBinding
+import io.github.kingg22.godot.internal.binding.VariantBinding
+import io.github.kingg22.godot.internal.binding.allocConstTypePtrArray
+import io.github.kingg22.godot.internal.binding.checkCallError
+import io.github.kingg22.godot.internal.ffi.GDExtensionMethodBindPtr
+import io.github.kingg22.godot.internal.ffi.GDExtensionObjectPtrVar
+import io.github.kingg22.godot.internal.ffi.GDExtensionPtrBuiltInMethod
+import io.github.kingg22.godot.internal.ffi.GDExtensionPtrConstructor
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.ExperimentalForeignApi
-
-private const val FRAME_COUNT = 1_000
-private const val START_FRAME = 100
-private const val SPRITE_COUNT = 5
+import kotlinx.cinterop.LongVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.invoke
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
 
 @Godot class SpriteBench(nativePtr: COpaquePointer) : Node2D(nativePtr) {
-    private val frameTimes = DoubleArray(FRAME_COUNT) { 0.0 }
-    private var currentFrame = 0
-    private var frameIndex = 0
-    private var windowSize: Vector2 = Vector2.ZERO
 
-    private val callable = Callable {
-        println("Hello from Kotlin inside a Callable!")
+    private val hintStr = "hint".asStringName()
+    private val punchStr = "punch".asStringName()
+
+    @RegisterSignal
+    private lateinit var hint: Signal
+
+    @RegisterSignal(RegisterSignal.Param(Variant.Type.INT, "value"))
+    private lateinit var punch: Signal
+
+    private val callable1 = Callable {
+        println("Callable1: received")
     }
 
     private val callable2 = Callable { id: Long ->
-        println("Hello from Kotlin inside a Callable with id: $id")
-        id
-    }
-
-    init {
-        GD.print("A new SpriteBench was created with pointer ${nativePtr.rawValue}")
+        println("Callable2: received $id")
     }
 
     override fun _ready() {
+        println("[SpriteBench] _ready started")
+        hint = signalFix(this, hintStr)
+        punch = signalFix(this, punchStr)
+
+        // ✅ connect después de validar
+        if (hint.isConnected(callable1)) {
+            println("hint already connected to callable1")
+        } else {
+            val result1 = hint.connect(callable1)
+            println("connect result: $result1 : ${GodotEnum.fromValue<GodotError>(result1)}")
+        }
+
+        if (punch.isConnected(callable2)) {
+            println("punch already connected to callable2")
+        } else {
+            val result = punch.connect(callable2)
+            println("connect punch result: $result : ${GodotEnum.fromValue<GodotError>(result)}")
+        }
+
+        // ✅ emit usando Signal directamente
         try {
-            println("[SpriteBench] _ready started")
+            println("[SpriteBench] emitting **hint** via Signal.emit fixed")
+            val error = hint.emitFix()
+            println("emitSignalFix hint returned: $error")
 
-            // Try to create Texture2D - but first let's test WITHOUT texture
-            val icon = ResourceLoader.instance.load("res://icon.svg".asGodotString()).castTo(::Texture2D)
-            println("[SpriteBench] Texture2D wrapper created")
+            println("[SpriteBench] emitting **punch** via Signal.emit fixed")
+            val error2 = punch.emitFix(12.asVariant())
+            println("emitSignalFix punch returned: $error2")
 
-            // get root from the engine singleton
-            val mainloop: SceneTree = Engine.instance.getMainLoop().castTo(::SceneTree)
-            // use mainloop to call the get_root from the scenetree class
-            val root: Window = mainloop.root // return as object
-            // use root as the object for the window class method to call get_size
-            val vpwh: Vector2i = root.size // return as Vector2i
-
-            windowSize = Vector2(from = vpwh)
-
-            val halfSize: Vector2 = icon.getSize() / 2.0
-            println(
-                "[SpriteBench] Window: (${windowSize.x}, ${windowSize.y}), HalfSize: (${halfSize.x}, ${halfSize.y})",
-            )
-
-            println("[SpriteBench] Creating $SPRITE_COUNT sprites")
-            for (i in 0..<SPRITE_COUNT) {
-                try {
-                    // Prefer the top-level factory function, this is a fallback way!!
-                    val sprite: Sprite = instantiate()
-                    sprite.halfSize = halfSize
-                    sprite.windowSize = windowSize
-                    sprite.pos = windowSize / 2.0
-                    sprite.position = sprite.pos
-                    sprite.texture = icon
-                    addChild(node = sprite)
-                    if (i % 1000 == 0) {
-                        println("[SpriteBench] Added $i sprites")
-                    }
-                } catch (e: Throwable) {
-                    println("[SpriteBench] === Sprite $i addChild failed ===")
-                    e.printStackTrace()
-                    throw e
-                }
-            }
-            println("[SpriteBench] All $SPRITE_COUNT sprites added successfully")
-
-            println("[SpriteBench] _ready finished, going to call deferred callable")
-            var returnVariant = callable.call()
-            println(
-                "[SpriteBench] Callable returned: ${returnVariant.stringify().toKString()}, is nil: ${returnVariant.isNil()}",
-            )
-            println("[SpriteBench] calling callable2 with 15 as args")
-            returnVariant = callable2.call(15L.asVariant())
-            println(
-                "[SpriteBench] Callable2 returned: ${returnVariant.stringify().toKString()}, is nil: ${returnVariant.isNil()}, value: ${returnVariant.asIntOrNull()}",
-            )
-        } catch (e: Throwable) {
-            println("[SpriteBench] === _ready failed ===")
-            e.printStackTrace()
+            /* ✅ emit usando Object.emitSignal FIX
+            println("[SpriteBench] emitting punch via emitSignalFix")
+            val err = emitSignalFix(punchStr, 200.asVariant())
+            println("emitSignalFix punch returned: $err")
+             */
+        } catch (e: Exception) {
+            println("emitSignalFix failed: ${e.message}")
+        } finally {
+            println("[SpriteBench] _ready finished")
         }
     }
+}
 
-    override fun _process(delta: Double) {
-        try {
-            currentFrame += 1
+fun signalFix(obj: GodotObject, signal: StringName) = Signal(null).apply {
+    memScoped {
+        val objectPtr = alloc<GDExtensionObjectPtrVar>()
+        objectPtr.`value` = obj.rawPtr
+        constructorFptr_2.invoke(
+            rawPtr,
+            allocConstTypePtrArray(
+                objectPtr.ptr,
+                signal.rawPtr,
+            ),
+        )
+    }
+}
 
-            if (currentFrame >= START_FRAME) {
-                if (frameIndex == FRAME_COUNT) {
-                    println("[SpriteBench] Frame count reached, freeing children")
-                    for (child in getChildren().asList()) {
-                        Node(child.asObject().rawPtr).queueFree()
-                    }
+private val constructorFptr_2: GDExtensionPtrConstructor by lazy(PUBLICATION) {
+    VariantBinding.instance.getPtrConstructorRaw(GDEXTENSION_VARIANT_TYPE_SIGNAL, 2)
+        ?: error("Missing builtin constructor for Signal[2]")
+}
 
-                    val outText = StringBuilder(FRAME_COUNT * 12)
-                    for (t in frameTimes) {
-                        outText.append("(").append(t).appendLine(")")
-                    }
-                    val edit = TextEdit()
-                    edit.text = outText.toString().asGodotString()
-                    edit.size = windowSize
-                    addChild(node = edit)
-                    println("[SpriteBench] TextEdit added")
-                } else if (frameIndex < FRAME_COUNT) {
-                    frameTimes[frameIndex] = delta
-                }
+fun Signal.emitFix(vararg args: Variant): GodotError = memScoped {
+    val retPtr = alloc<LongVar>()
+    methodSignalEmit_3286317445_Fn.invoke(
+        rawPtr,
+        allocConstTypePtrArray(*args.map { it.rawPtr }.toTypedArray()),
+        retPtr.ptr,
+        args.size,
+    )
+    return GodotEnum.fromValue(retPtr.value)
+}
 
-                frameIndex += 1
-            }
-        } catch (e: Throwable) {
-            println("[SpriteBench] === _process failed ===")
-            e.printStackTrace()
+private val methodSignalEmit_3286317445_Fn: GDExtensionPtrBuiltInMethod by lazy(PUBLICATION) {
+    StringName("emit").use { name ->
+        VariantBinding.instance.getPtrBuiltinMethodRaw(GDEXTENSION_VARIANT_TYPE_SIGNAL, name.rawPtr, 3_286_317_445L)
+            ?: error("Missing builtin method 'Signal.emit' hash: 3286317445")
+    }
+}
+
+// **have errors**
+fun GodotObject.emitSignalFix(signal: StringName, vararg args: Variant): GodotError = memScoped {
+    val retPtr = alloc<LongVar>()
+
+    val callError = ObjectBinding.instance.methodBindCall(
+        methodObjectEmitSignal_Bind,
+        rawPtr,
+        signal.asVariant().rawPtr,
+        *args.map { it.rawPtr }.toTypedArray(),
+        rRet = retPtr.ptr,
+    )
+
+    checkCallError("emitSignal of $signal", callError)
+
+    return GodotEnum.fromValue(retPtr.value)
+}
+
+private val methodObjectEmitSignal_Bind: GDExtensionMethodBindPtr by lazy(PUBLICATION) {
+    StringName("Object").use { cn ->
+        StringName("emit_signal").use { mn ->
+            ClassDBBinding.instance.getMethodBindRaw(cn.rawPtr, mn.rawPtr, 4_047_867_050L)
+                ?: error("Missing method bind 'Object.emit_signal', hash: 4_047_867_050")
         }
     }
 }

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/TestOne.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/TestOne.kt
@@ -1,0 +1,138 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+import io.github.kingg22.godot.api.annotations.Godot
+import io.github.kingg22.godot.api.builtin.Callable
+import io.github.kingg22.godot.api.builtin.Vector2
+import io.github.kingg22.godot.api.builtin.Vector2i
+import io.github.kingg22.godot.api.builtin.asGodotString
+import io.github.kingg22.godot.api.builtin.asVariant
+import io.github.kingg22.godot.api.core.Node
+import io.github.kingg22.godot.api.core.SceneTree
+import io.github.kingg22.godot.api.core.node.Node2D
+import io.github.kingg22.godot.api.core.node.TextEdit
+import io.github.kingg22.godot.api.core.node.Window
+import io.github.kingg22.godot.api.core.refcounted.Texture2D
+import io.github.kingg22.godot.api.singleton.Engine
+import io.github.kingg22.godot.api.singleton.ResourceLoader
+import io.github.kingg22.godot.api.utils.GD
+import io.github.kingg22.godot.api.utils.print
+import io.github.kingg22.godot.binding.instantiate
+import io.github.kingg22.godot.castTo
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.ExperimentalForeignApi
+
+private const val FRAME_COUNT = 1_000
+private const val START_FRAME = 100
+private const val SPRITE_COUNT = 5
+
+@Godot class TestOne(nativePtr: COpaquePointer) : Node2D(nativePtr) {
+    private val frameTimes = DoubleArray(FRAME_COUNT) { 0.0 }
+    private var currentFrame = 0
+    private var frameIndex = 0
+    private var windowSize: Vector2 = Vector2.ZERO
+
+    private val callable = Callable {
+        println("Hello from Kotlin inside a Callable!")
+    }
+
+    private val callable2 = Callable { id: Long ->
+        println("Hello from Kotlin inside a Callable with id: $id")
+        id
+    }
+
+    init {
+        GD.print("A new SpriteBench was created with pointer ${nativePtr.rawValue}")
+    }
+
+    override fun _ready() {
+        try {
+            println("[SpriteBench] _ready started")
+
+            // Try to create Texture2D - but first let's test WITHOUT texture
+            val icon = ResourceLoader.instance.load("res://icon.svg".asGodotString()).castTo(::Texture2D)
+            println("[SpriteBench] Texture2D wrapper created")
+
+            // get root from the engine singleton
+            val mainloop: SceneTree = Engine.instance.getMainLoop().castTo(::SceneTree)
+            // use mainloop to call the get_root from the scenetree class
+            val root: Window = mainloop.root // return as object
+            // use root as the object for the window class method to call get_size
+            val vpwh: Vector2i = root.size // return as Vector2i
+
+            windowSize = Vector2(from = vpwh)
+
+            val halfSize: Vector2 = icon.getSize() / 2.0
+            println(
+                "[SpriteBench] Window: (${windowSize.x}, ${windowSize.y}), HalfSize: (${halfSize.x}, ${halfSize.y})",
+            )
+
+            println("[SpriteBench] Creating $SPRITE_COUNT sprites")
+            for (i in 0..<SPRITE_COUNT) {
+                try {
+                    // Prefer the top-level factory function, this is a fallback way!!
+                    val sprite: Sprite = instantiate()
+                    sprite.halfSize = halfSize
+                    sprite.windowSize = windowSize
+                    sprite.pos = windowSize / 2.0
+                    sprite.position = sprite.pos
+                    sprite.texture = icon
+                    addChild(node = sprite)
+                    if (i % 1000 == 0) {
+                        println("[SpriteBench] Added $i sprites")
+                    }
+                } catch (e: Throwable) {
+                    println("[SpriteBench] === Sprite $i addChild failed ===")
+                    e.printStackTrace()
+                    throw e
+                }
+            }
+            println("[SpriteBench] All $SPRITE_COUNT sprites added successfully")
+
+            println("[SpriteBench] _ready finished, going to call deferred callable")
+            var returnVariant = callable.call()
+            println(
+                "[SpriteBench] Callable returned: ${returnVariant.stringify().toKString()}, is nil: ${returnVariant.isNil()}",
+            )
+            println("[SpriteBench] calling callable2 with 15 as args")
+            returnVariant = callable2.call(15L.asVariant())
+            println(
+                "[SpriteBench] Callable2 returned: ${returnVariant.stringify().toKString()}, is nil: ${returnVariant.isNil()}, value: ${returnVariant.asIntOrNull()}",
+            )
+        } catch (e: Throwable) {
+            println("[SpriteBench] === _ready failed ===")
+            e.printStackTrace()
+        }
+    }
+
+    override fun _process(delta: Double) {
+        try {
+            currentFrame += 1
+
+            if (currentFrame >= START_FRAME) {
+                if (frameIndex == FRAME_COUNT) {
+                    println("[SpriteBench] Frame count reached, freeing children")
+                    for (child in getChildren().asList()) {
+                        Node(child.asObject().rawPtr).queueFree()
+                    }
+
+                    val outText = StringBuilder(FRAME_COUNT * 12)
+                    for (t in frameTimes) {
+                        outText.append("(").append(t).appendLine(")")
+                    }
+                    val edit = TextEdit()
+                    edit.text = outText.toString().asGodotString()
+                    edit.size = windowSize
+                    addChild(node = edit)
+                    println("[SpriteBench] TextEdit added")
+                } else if (frameIndex < FRAME_COUNT) {
+                    frameTimes[frameIndex] = delta
+                }
+
+                frameIndex += 1
+            }
+        } catch (e: Throwable) {
+            println("[SpriteBench] === _process failed ===")
+            e.printStackTrace()
+        }
+    }
+}

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt
@@ -148,9 +148,19 @@ class KogotProcessor(environment: SymbolProcessorEnvironment) : SymbolProcessor 
 
     private fun runGeneration(classes: List<KSClassDeclaration>): GeneratedOutput {
         val classInfos = classes.map { it.toClassInfo() }
+
+        // Build property annotations map: classQualifiedName -> propertyName -> annotations
+        val propertyAnnotations = classes.associate { ksClass ->
+            val qName = ksClass.qualifiedName?.asString() ?: ""
+            qName to ksClass.getAllProperties().associate { prop ->
+                prop.simpleName.asString() to prop.annotations.toList()
+            }
+        }
+
         val context = GeneratorContext(
             outputPackage = options.generatedPackage,
             options = GeneratorOptions(),
+            propertyAnnotations = propertyAnnotations,
         )
 
         val outputs = mutableListOf<GeneratedOutput>()

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/bridge/KspAnalysisContext.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/bridge/KspAnalysisContext.kt
@@ -121,13 +121,28 @@ fun KSAnnotation.toAnnotationInfo(): AnnotationInfo {
                 if (typeDecl is KSClassDeclaration) {
                     typeDecl.qualifiedName?.asString() ?: "unknown"
                 } else {
-                    "unknown"
+                    typeDecl.toString()
                 }
             }
 
             is KSAnnotation -> v.toAnnotationInfo()
 
-            is List<*> -> v.toString()
+            is List<*> -> v.mapNotNull { element ->
+                when (element) {
+                    is KSAnnotation -> element.toAnnotationInfo()
+
+                    is KSType -> {
+                        val typeDecl = element.declaration
+                        if (typeDecl is KSClassDeclaration) {
+                            typeDecl.qualifiedName?.asString()
+                        } else {
+                            element.toString()
+                        }
+                    }
+
+                    else -> element?.toString()
+                }
+            }
 
             else -> v
         }

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/Generator.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/Generator.kt
@@ -1,12 +1,21 @@
 package io.github.kingg22.kogot.processor.generation
 
+import com.google.devtools.ksp.symbol.KSAnnotation
 import io.github.kingg22.kogot.analysis.models.ClassInfo
 import io.github.kingg22.kogot.processor.diagnostics.DiagnosticMessage
 
 /**
  * Context for code generation.
  */
-data class GeneratorContext(val outputPackage: String, val options: GeneratorOptions)
+data class GeneratorContext(
+    val outputPackage: String,
+    val options: GeneratorOptions,
+    /**
+     * Raw KSP annotations keyed by class qualified name and property name.
+     * Structure: classQualifiedName -> propertyName -> annotations
+     */
+    val propertyAnnotations: Map<String, Map<String, List<KSAnnotation>>> = emptyMap(),
+)
 
 /**
  * Options for generators.

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/kotlin/Constants.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/kotlin/Constants.kt
@@ -41,6 +41,15 @@ val CREATE_FREE_INSTANCE_FUN = MemberName(GODOT_INTERNAL_BINDING_PKG, "createFre
 
 val REGISTER_CLASS = MemberName(GODOT_INTERNAL_BINDING_PKG, "registerClass")
 
+val REGISTER_CUSTOM_SIGNAL = MemberName(GODOT_INTERNAL_BINDING_PKG, "registerCustomSignal")
+
+val REGISTER_SIGNAL_CLASS_NAME = ClassName("$GODOT_PKG.api.annotations", "RegisterSignal")
+
+val REGISTER_SIGNAL_PARAM_CLASS_NAME = ClassName("$GODOT_PKG.api.annotations", "RegisterSignal", "Param")
+
+val VARIANT_CLASS_NAME = ClassName("$GODOT_PKG.api.builtin", "Variant")
+val VARIANT_TYPE_CLASS_NAME = VARIANT_CLASS_NAME.nestedClass("Type")
+
 val CREATE_INSTANCE_FUN = MemberName(GODOT_INTERNAL_BINDING_PKG, "createInstanceFunc")
 
 val ClassDBClassName = ClassName("$GODOT_PKG.api.singleton", "ClassDB")

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/kotlin/GodotBindingGenerator.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generation/kotlin/GodotBindingGenerator.kt
@@ -1,11 +1,14 @@
 package io.github.kingg22.kogot.processor.generation.kotlin
 
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
 import io.github.kingg22.kogot.analysis.models.ClassInfo
+import io.github.kingg22.kogot.analysis.models.PropertyInfo
 import io.github.kingg22.kogot.analysis.models.getParentClassShortName
 import io.github.kingg22.kogot.analysis.models.hasGodotAnnotation
 import io.github.kingg22.kogot.analysis.models.inheritsFromNode2D
@@ -33,7 +36,8 @@ class GodotBindingGenerator : Generator {
 
         for (classInfo in godotClasses) {
             try {
-                files.add(generateBindingFile(classInfo))
+                val propertyAnnotations = context.propertyAnnotations[classInfo.qualifiedName] ?: emptyMap()
+                files.add(generateBindingFile(classInfo, propertyAnnotations))
             } catch (e: Exception) {
                 diagnostics.add(
                     DiagnosticMessage.error(
@@ -54,7 +58,10 @@ class GodotBindingGenerator : Generator {
         return GeneratedOutput(files, diagnostics)
     }
 
-    private fun generateBindingFile(classInfo: ClassInfo): GeneratedFile {
+    private fun generateBindingFile(
+        classInfo: ClassInfo,
+        propertyAnnotations: Map<String, List<KSAnnotation>>,
+    ): GeneratedFile {
         val bindingClassName = "${classInfo.shortName}_Binding"
         val packageName = classInfo.packageName
 
@@ -77,7 +84,7 @@ class GodotBindingGenerator : Generator {
         val typeSpec = TypeSpec
             .objectBuilder(bindingClassName)
             .addAnnotation(InternalBindingClassName)
-            .addFunction(generateRegisterFun(classInfo, classType, godotBaseClass))
+            .addFunction(generateRegisterFun(classInfo, classType, godotBaseClass, propertyAnnotations))
             .build()
 
         // fileSpec.addFunction(generateCreateInstanceFun(classInfo, classType, godotBaseClass))
@@ -92,38 +99,96 @@ class GodotBindingGenerator : Generator {
         )
     }
 
-    private fun generateCreateInstanceFun(classInfo: ClassInfo, classType: ClassName, godotBaseClass: String) = FunSpec
-        .builder(classInfo.shortName)
-        .returns(classType)
-        .addCode("return %T(\n", classType)
-        .addStatement("⇥%M(", CREATE_INSTANCE_FUN)
-        .addStatement("⇥%S,", godotBaseClass)
-        .addStatement("%S,", classInfo.shortName)
-        .addStatement("::%T,", classType)
-        .addStatement("⇤)!!,")
-        .addCode("⇤)")
-        .build()
+    private fun generateRegisterFun(
+        classInfo: ClassInfo,
+        classType: ClassName,
+        baseClass: String,
+        propertyAnnotations: Map<String, List<KSAnnotation>>,
+    ): FunSpec {
+        val funSpec = FunSpec
+            .builder("register")
+            .addStatement("%M<%T>(", REGISTER_CLASS, classType)
+            .addStatement("⇥%S,", classInfo.shortName)
+            .addStatement("%S,", baseClass)
+            .addStatement("%M { _, notifyPostInitialize ->", STATIC_C_FUNCTION)
+            .addStatement(
+                "⇥%M(%S, %S, ::%T, notifyPostInitialize == %T.%M)⇤",
+                CREATE_INSTANCE_FUN,
+                baseClass,
+                classInfo.shortName,
+                classType,
+                GDExtensionBoolClassName,
+                GDExtensionBoolTrueMember,
+            )
+            .addStatement("},")
+            .addStatement("%M(),", CREATE_FREE_INSTANCE_FUN)
+            .addStatement("%T.getVirtual,", NodeVirtualDispatcherClassName)
+            .addStatement("⇤)")
 
-    private fun generateRegisterFun(classInfo: ClassInfo, classType: ClassName, baseClass: String): FunSpec = FunSpec
-        .builder("register")
-        .addStatement("%M<%T>(", REGISTER_CLASS, classType)
-        .addStatement("⇥%S,", classInfo.shortName)
-        .addStatement("%S,", baseClass)
-        .addStatement("%M { _, notifyPostInitialize ->", STATIC_C_FUNCTION)
-        .addStatement(
-            "⇥%M(%S, %S, ::%T, notifyPostInitialize == %T.%M)⇤",
-            CREATE_INSTANCE_FUN,
-            baseClass,
-            classInfo.shortName,
-            classType,
-            GDExtensionBoolClassName,
-            GDExtensionBoolTrueMember,
-        )
-        .addStatement("},")
-        .addStatement("%M(),", CREATE_FREE_INSTANCE_FUN)
-        .addStatement("%T.getVirtual,", NodeVirtualDispatcherClassName)
-        .addStatement("⇤)")
-        .build()
+        // Add signal registrations
+        val registerSignalProperties = classInfo.properties.filter { prop ->
+            propertyAnnotations[prop.name]
+                ?.any { it.shortName.asString() == "RegisterSignal" }
+                ?: false
+        }
+
+        for (prop in registerSignalProperties) {
+            val ksAnnotation = propertyAnnotations[prop.name]
+                ?.first { it.shortName.asString() == "RegisterSignal" }
+            if (ksAnnotation != null) {
+                val annotationCode = buildRegisterSignalAnnotationFromKSAnnotation(prop, ksAnnotation)
+                funSpec
+                    .addStatement("%M(⇥", REGISTER_CUSTOM_SIGNAL)
+                    .addStatement("%S,", classInfo.shortName)
+                    .addCode("%L", annotationCode)
+                    .addStatement("⇤)")
+            }
+        }
+
+        return funSpec.build()
+    }
+
+    private fun buildRegisterSignalAnnotationFromKSAnnotation(
+        prop: PropertyInfo,
+        annotation: KSAnnotation,
+    ): CodeBlock {
+        val builder = CodeBlock.builder()
+        builder.addStatement("%T(⇥", REGISTER_SIGNAL_CLASS_NAME)
+
+        // Extract params from the KSAnnotation directly
+        val paramsArg = annotation.arguments.find { it.name?.asString() == "params" }
+        val nameArg = annotation.arguments.find { it.name?.asString() == "name" }
+
+        val signalName = nameArg?.value?.toString()?.takeIf { it.isNotEmpty() } ?: prop.name
+
+        // Handle params list
+        val paramsList = paramsArg?.value as? List<*>
+        val paramAnnotations = paramsList.orEmpty().filterIsInstance<KSAnnotation>()
+
+        if (paramAnnotations.isNotEmpty()) {
+            paramAnnotations.forEach { paramAnn ->
+                // Extract type and name from the param annotation
+                val typeArg = paramAnn.arguments.find { it.name?.asString() == "type" }
+                val nameArgVal = paramAnn.arguments.find { it.name?.asString() == "name" }
+                val paramName = nameArgVal?.value?.toString().orEmpty()
+                val typeEntry = typeArg?.value?.toString()
+                    ?: error(
+                        "Missing type for signal parameter in ${prop.name}, signal param: $paramName. Type arg: $typeArg",
+                    )
+                builder.addStatement(
+                    "%T(%T.%L, %S),", // Param(Variant.Type.NIL, "name")
+                    REGISTER_SIGNAL_PARAM_CLASS_NAME,
+                    VARIANT_CLASS_NAME,
+                    typeEntry,
+                    paramName,
+                )
+            }
+        }
+        builder.addStatement("name = %S,", signalName)
+        builder.addStatement("⇤),")
+
+        return builder.build()
+    }
 
     private fun generateCallbacksFile(classes: List<ClassInfo>): GeneratedFile {
         val packageName = classes.first().packageName + ".generated"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -73,6 +73,7 @@ include(
     "kotlin-native:ffi",
     "kotlin-native:api",
     "kotlin-native:api:annotations",
+    "kotlin-native:api:callable",
     "kotlin-native:api:chore",
     "kotlin-native:api:generated",
     "kotlin-native:api:signal",


### PR DESCRIPTION
Closes #41

## Summary by Sourcery

Agregar soporte para registrar y emitir señales personalizadas de Godot desde Kotlin, incluyendo metadatos de señales basados en anotaciones y enlaces invocables de bajo nivel, junto con ejemplos de uso y cambios de infraestructura de soporte.

New Features:
- Introduce la anotación `@RegisterSignal` para declarar señales de Godot en propiedades de Kotlin con metadatos de parámetros.
- Agrega utilidades de enlace y registro para registrar señales personalizadas en Godot en tiempo de ejecución usando los datos de anotación.
- Añade un módulo de API de callable dedicado y un `CallableBinding` de bajo nivel para admitir callables personalizados de Kotlin invocados desde Godot.
- Extiende la generación de `Variant` para admitir la construcción de `Variant` a partir de valores `Object` y manejar tipos `OBJECT` en la resolución.
- Proporciona helpers de `EnumMask` para construir máscaras a partir de colecciones y convertir colecciones de enums en instancias de `EnumMask`.
- Agrega un nuevo nodo de Godot `TestOne` que muestra la creación de sprites y la invocación de callables por separado de `SpriteBench`.

Enhancements:
- Conecta el generador KSP para capturar anotaciones de propiedades sin procesar y generar código de registro de señales basado en el uso de `@RegisterSignal`.
- Mejora el manejo de `KSAnnotation.toAnnotationInfo` para listas, preservando anotaciones anidadas e información de tipos en lugar de convertirlas a cadenas.
- Refactoriza `SpriteBench` para que actúe como un área de pruebas de señales/callables que emite y conecta señales personalizadas en lugar de lógica de benchmarking de sprites.
- Registra tipos FFI adicionales en `ImplementationPackageRegistry` necesarios para los nuevos enlaces de callables y señales.

Build:
- Agrega un nuevo módulo `kotlin-native:api:callable` con su propia configuración de Gradle y ajustes de codegen.
- Actualiza la configuración del proyecto para incluir el nuevo módulo de API de callable en la build.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for registering and emitting custom Godot signals from Kotlin, including annotation-based signal metadata and low-level callable bindings, along with example usage and supporting infrastructure changes.

New Features:
- Introduce @RegisterSignal annotation for declaring Godot signals on Kotlin properties with parameter metadata.
- Add binding and registration utilities to register custom signals with Godot at runtime using annotation data.
- Add a dedicated callable API module and low-level CallableBinding to support custom Kotlin callables invoked from Godot.
- Extend Variant generation to support constructing Variants from Object values and handling OBJECT types in resolution.
- Provide EnumMask helpers to build masks from collections and convert enum collections to EnumMask instances.
- Add a new TestOne Godot node showcasing sprite creation and callable invocation separate from SpriteBench.

Enhancements:
- Wire KSP generator to capture raw property annotations and generate signal registration code based on @RegisterSignal usage.
- Improve KSAnnotation toAnnotationInfo handling for lists by preserving nested annotations and type information instead of stringifying.
- Refactor SpriteBench to act as a signal/Callable playground emitting and connecting custom signals instead of sprite benchmarking logic.
- Register additional FFI types in ImplementationPackageRegistry needed for new callable and signal bindings.

Build:
- Add a new kotlin-native:api:callable module with its own Gradle configuration and codegen settings.
- Update project settings to include the new callable API module in the build.

</details>