### PR TITLE
fix: object ptr to ptr constructor

### DIFF
--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/BuiltinClassImplGen.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/BuiltinClassImplGen.kt
@@ -629,25 +629,45 @@ class BuiltinClassImplGen(private val typeResolver: TypeResolver, private val me
             val ptrExprs = args.map { arg ->
                 val kotlinName = safeIdentifier(arg.name)
                 val varName = "${kotlinName}Var"
-                when (val kotlinType = typeResolver.resolve(arg.type, arg.meta)) {
-                    BOOLEAN -> {
+                val kotlinType = typeResolver.resolve(arg.type, arg.meta)
+
+                when {
+                    kotlinType == BOOLEAN -> {
                         addStatement(
                             "val %N = %M(%N)",
                             varName,
                             implPackageRegistry.memberNameForOrDefault("allocGdBool"),
                             kotlinName,
                         )
-                        CodeBlock.builder().addStatement("%N,", varName).build()
+                        CodeBlock.ofStatement("%N,", varName)
                     }
 
-                    FLOAT, DOUBLE, INT, LONG, BYTE, SHORT, U_BYTE, U_SHORT, U_INT, U_LONG -> {
+                    kotlinType in listOf(FLOAT, DOUBLE, INT, LONG, BYTE, SHORT, U_BYTE, U_SHORT, U_INT, U_LONG) -> {
                         val cVarType = primitiveKotlinToCVar(kotlinType) ?: error("Unsupported type: $kotlinType")
                         addStatement("val %N = %M<%T>()", varName, cinteropAlloc, cVarType)
                         addStatement("%N.%M = %N", varName, cinteropValue, kotlinName)
-                        CodeBlock.builder().addStatement("%N.%M,", varName, cinteropPtr).build()
+                        CodeBlock.ofStatement("%N.%M,", varName, cinteropPtr)
                     }
 
-                    else -> CodeBlock.builder().addStatement("%N.rawPtr,", kotlinName).build()
+                    context.isEngineClass(arg.type) -> {
+                        // Engine class (Object, etc.) needs void** (PtrToArg<Object*> semantics)
+                        addStatement(
+                            "val %N = %M<%T>()",
+                            varName,
+                            cinteropAlloc,
+                            implPackageRegistry.classNameForOrDefault("GDExtensionObjectPtrVar"),
+                        )
+                        addStatement(
+                            "%N.%M = %N%L.rawPtr",
+                            varName,
+                            cinteropValue,
+                            kotlinName,
+                            if (arg.isNullable) "?" else "",
+                        )
+                        CodeBlock.ofStatement("%N.%M,", varName, cinteropPtr)
+                    }
+
+                    else -> CodeBlock.ofStatement("%N.rawPtr,", kotlinName)
                 }
             }
 

--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VariantImplGen.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VariantImplGen.kt
@@ -222,6 +222,7 @@ class VariantImplGen(private val typeResolver: TypeResolver) {
                 .build(),
         )
 
+        // Special constructor of Object, requires ptr to ptr
         classBuilder.addFunction(
             FunSpec
                 .constructorBuilder()
@@ -232,12 +233,12 @@ class VariantImplGen(private val typeResolver: TypeResolver) {
                         .builder()
                         .beginControlFlow("%M", memScoped)
                         .addStatement(
-                            "val objPtr = %M<%T>()",
+                            "val objectVar = %M<%T>()",
                             cinteropAlloc,
                             implPackageRegistry.classNameForOrDefault("GDExtensionObjectPtrVar"),
                         )
-                        .addStatement("objPtr.%M = value.rawPtr", cinteropValue)
-                        .addStatement("fromTypeFptr_%L.%M(rawPtr, objPtr.%M)", "OBJECT", cinteropInvoke, cinteropPtr)
+                        .addStatement("objectVar.%M = value.rawPtr", cinteropValue)
+                        .addStatement("fromTypeFptr_%L.%M(rawPtr, objectVar.%M)", "OBJECT", cinteropInvoke, cinteropPtr)
                         .endControlFlow()
                         .build(),
                 )

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/SpriteBench.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/SpriteBench.kt
@@ -10,13 +10,10 @@ import io.github.kingg22.godot.api.builtin.StringName
 import io.github.kingg22.godot.api.builtin.Variant
 import io.github.kingg22.godot.api.builtin.toStringName
 import io.github.kingg22.godot.api.builtin.toVariant
-import io.github.kingg22.godot.api.core.Object
 import io.github.kingg22.godot.api.core.node.Node2D
 import io.github.kingg22.godot.internal.binding.VariantBinding
 import io.github.kingg22.godot.internal.binding.allocConstTypePtrArray
-import io.github.kingg22.godot.internal.ffi.GDExtensionObjectPtrVar
 import io.github.kingg22.godot.internal.ffi.GDExtensionPtrBuiltInMethod
-import io.github.kingg22.godot.internal.ffi.GDExtensionPtrConstructor
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.LongVar
@@ -32,10 +29,10 @@ import kotlinx.cinterop.value
     private val punchStr = "punch".toStringName()
 
     @RegisterSignal
-    private lateinit var hint: Signal
+    private val hint by lazy { Signal(this, hintStr) }
 
     @RegisterSignal(RegisterSignal.Param(Variant.Type.INT, "value"))
-    private lateinit var punch: Signal
+    private val punch by lazy { Signal(this, punchStr) }
 
     private val callable1 = Callable {
         println("Callable1: received")
@@ -47,8 +44,6 @@ import kotlinx.cinterop.value
 
     override fun _ready() {
         println("[SpriteBench] _ready started")
-        hint = signalFix(this, hintStr)
-        punch = signalFix(this, punchStr)
 
         // ✅ connect después de validar
         if (hint.isConnected(callable1)) {
@@ -87,25 +82,6 @@ import kotlinx.cinterop.value
             println("[SpriteBench] _ready finished")
         }
     }
-}
-
-fun signalFix(obj: Object, signal: StringName) = Signal(null).apply {
-    memScoped {
-        val objectPtr = alloc<GDExtensionObjectPtrVar>()
-        objectPtr.`value` = obj.rawPtr
-        constructorFptr_2.invoke(
-            rawPtr,
-            allocConstTypePtrArray(
-                objectPtr.ptr,
-                signal.rawPtr,
-            ),
-        )
-    }
-}
-
-private val constructorFptr_2: GDExtensionPtrConstructor by lazy(PUBLICATION) {
-    VariantBinding.instance.getPtrConstructorRaw(GDEXTENSION_VARIANT_TYPE_SIGNAL, 2)
-        ?: error("Missing builtin constructor for Signal[2]")
 }
 
 fun Signal.emitFix(vararg args: Variant): GodotError = memScoped {


### PR DESCRIPTION
Based on investigation of Minimax, currently only constructors have issues to bind correctly Object to FFI.

Closes #92

## Summary by Sourcery

Corregir los enlaces FFI para los constructores de objetos del motor y limpiar el uso de señales en el ejemplo.

Correcciones de errores:
- Corregir el *marshalling* de argumentos FFI para que las clases del motor (por ejemplo, Object) se pasen como puntero a puntero cuando lo requiera la API de extensiones de Godot.
- Arreglar la construcción de Variant(Object) envolviendo el puntero del objeto en un GDExtensionObjectPtrVar antes de invocar el constructor subyacente.

Mejoras:
- Simplificar la inicialización de señales en el ejemplo SpriteBench usando propiedades de Signal perezosas en lugar de un helper de constructor personalizado y un registro manual.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix FFI bindings for engine object constructors and clean up sample signal usage.

Bug Fixes:
- Correct FFI argument marshalling so engine classes (e.g. Object) are passed as pointer-to-pointer where required by the Godot extension API.
- Fix Variant(Object) construction by wrapping the object pointer in a GDExtensionObjectPtrVar before invoking the underlying constructor.

Enhancements:
- Simplify signal initialization in the SpriteBench sample by using lazy Signal properties instead of a custom constructor helper and manual registration.

</details>