### PR TITLE
Feat: custom method binding

### DIFF
--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/Shared.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/Shared.kt
@@ -245,12 +245,19 @@ fun buildReturnAlloc(
             // Vector2i(rawPtr = null) -> nativeHeap.alloc(size, align)); mirrors buildOperatorBody.
             ctx.isBuiltin(returnType) -> addStatement("val retPtr = %T()", kotlinType)
 
+            // Array/Dictionary/TypedArray/TypedDictionary are Variant-compatible builtins too, just
+            // spelled with lowercase/compound type strings ("array", "typedarray::Node", ...) that
+            // never satisfy ctx.isBuiltin's exact-name check. Godot's ptrcall performs a real
+            // assignment into the destination (releasing/retaining the internal refcounted pointer),
+            // not a raw pointer write — the destination must be an already-constructed, valid empty
+            // container. Same fix pattern as the scalar builtins above.
             returnType.startsWith("array") ||
                 returnType.startsWith("dictionary") ||
                 returnType.startsWith("typeddictionary") ||
-                returnType.startsWith("typedarray") ||
-                kotlinType == COPAQUE_POINTER ||
-                ctx.isEngineClass(returnType) ->
+                returnType.startsWith("typedarray") ->
+                addStatement("val retPtr = %T()", kotlinType)
+
+            kotlinType == COPAQUE_POINTER || ctx.isEngineClass(returnType) ->
                 addStatement("val retPtr = %M<%T>()", cinteropAlloc, C_OPAQUE_POINTER_VAR)
 
             kotlinType is ParameterizedTypeName && kotlinType.rawType == C_POINTER -> addStatement(
@@ -312,11 +319,14 @@ fun buildReturnRead(
         // straight into its own native storage, so there's no pointer to dereference or null-check.
         ctx.isBuiltin(returnType) -> CodeBlock.ofStatement("${preAppendReturn}retPtr")
 
-        ctx.isEngineClass(returnType) ||
-            returnType.startsWith("array") ||
+        // retPtr is already the constructed container instance (see buildReturnAlloc) — ptrcall
+        // assigned straight into it, so there's no pointer to dereference or null-check either.
+        returnType.startsWith("array") ||
             returnType.startsWith("dictionary") ||
             returnType.startsWith("typeddictionary") ||
-            returnType.startsWith("typedarray") -> {
+            returnType.startsWith("typedarray") -> CodeBlock.ofStatement("${preAppendReturn}retPtr")
+
+        ctx.isEngineClass(returnType) -> {
             CodeBlock
                 .builder()
                 .addStatement("$preAppendReturn%T(", kotlinType)
@@ -442,9 +452,11 @@ data class ReturnArgInfo(
  * - `bool` → needsPtrInInvoke=false, asCodeBlock="retPtr" (GdBool instance, not pointer)
  * - CVar types (Int, Long, Float, Double, etc.) → needsPtrInInvoke=true, asCodeBlock="retPtr.%M" (cinteropPtr)
  * - COPAQUE_POINTER, enums, bitfields, C_POINTER → needsPtrInInvoke=false, asCodeBlock="retPtr.%M" (cinteropPtr)
- * - Builtins → needsPtrInInvoke=false, asCodeBlock="retPtr.rawPtr" (retPtr is the constructed instance
- *   from [buildReturnAlloc]; its own rawPtr is already the correctly-sized destination, no reinterpret)
- * - Engine classes, arrays, dicts, typed dicts, typed arrays:
+ * - Builtins, arrays, dicts, typed dicts, typed arrays → needsPtrInInvoke=false, asCodeBlock="retPtr.rawPtr"
+ *   (retPtr is the constructed instance from [buildReturnAlloc]; its own rawPtr is already the
+ *   correctly-sized destination — a struct for builtins, an already-constructed container for
+ *   arrays/dicts — no reinterpret needed)
+ * - Engine classes:
  *   - forBuiltinInvoke=true → needsPtrInInvoke=true, asCodeBlock="retPtr.%M.%M()" (cinteropPtr.reinterpret())
  *   - forBuiltinInvoke=false → needsPtrInInvoke=true, asCodeBlock="retPtr.%M" (cinteropPtr)
  * - Fallback → needsPtrInInvoke=false, asCodeBlock="retPtr"
@@ -459,15 +471,19 @@ fun returnArgExpression(returnType: String?, kotlinType: TypeName, forBuiltinInv
     // Godot's own builtin_classes list includes those alongside Vector2i/Color/etc.
     val isBuiltinReturn = returnType != null && cVarType == null && ctx.isBuiltin(returnType)
 
-    // Engine classes and collections: need raw pointer for the invoke call.
-    // The type is constructed via reinterpret() after the call (BuiltinMethodImplGen path).
-    val isEngineOrCollection = returnType != null && (
-        ctx.findEngineClass(returnType) != null ||
-            returnType.startsWith("array") ||
+    // Array/Dictionary/TypedArray/TypedDictionary: same "already constructed instance" pattern as
+    // isBuiltinReturn above (see buildReturnAlloc) — these lowercase/compound type strings never
+    // satisfy ctx.isBuiltin's exact-name check, so they need their own explicit condition here.
+    val isCollectionReturn = returnType != null && (
+        returnType.startsWith("array") ||
             returnType.startsWith("dictionary") ||
             returnType.startsWith("typeddictionary") ||
             returnType.startsWith("typedarray")
         )
+
+    // Engine classes: need raw pointer for the invoke call.
+    // The type is constructed via reinterpret() after the call (BuiltinMethodImplGen path).
+    val isEngineReturn = returnType != null && ctx.findEngineClass(returnType) != null
 
     // CVar types (IntVar, LongVar, etc.): need pointer to stack-allocated variable.
     val isCVar = cVarType != null
@@ -482,8 +498,10 @@ fun returnArgExpression(returnType: String?, kotlinType: TypeName, forBuiltinInv
 
         isBuiltinReturn -> ReturnArgInfo(CodeBlock.of("retPtr.rawPtr"), needsPtrInInvoke = false)
 
-        isEngineOrCollection ->
-            // Engine/collection types: invoke needs retPtr.%M (the raw pointer).
+        isCollectionReturn -> ReturnArgInfo(CodeBlock.of("retPtr.rawPtr"), needsPtrInInvoke = false)
+
+        isEngineReturn ->
+            // Engine types: invoke needs retPtr.%M (the raw pointer).
             // asCodeBlock differs based on context:
             // - forBuiltinInvoke=true: include .reinterpret() for post-call type construction
             // - forBuiltinInvoke=false: just retPtr.%M for methodBindPtrcallRaw

--- a/kotlin-native/api/annotations/src/nativeMain/kotlin/io/github/kingg22/godot/api/annotations/ExportMethod.kt
+++ b/kotlin-native/api/annotations/src/nativeMain/kotlin/io/github/kingg22/godot/api/annotations/ExportMethod.kt
@@ -1,0 +1,13 @@
+package io.github.kingg22.godot.api.annotations
+
+/**
+ * Mark the following method as callable from GDScript, the editor, or other Godot APIs
+ * (e.g. `Object.call()`, signal connections, `Callable`).
+ *
+ * Parameter and return types must be representable as a [io.github.kingg22.godot.api.builtin.Variant]
+ * (primitives or Godot builtin types). Default parameter values are not supported yet.
+ */
+@Retention(SOURCE)
+@Target(FUNCTION)
+@MustBeDocumented
+public annotation class ExportMethod

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/GodotArrayIterator.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/GodotArrayIterator.kt
@@ -1,4 +1,0 @@
-import io.github.kingg22.godot.api.builtin.GodotArray
-import io.github.kingg22.godot.api.builtin.Variant
-
-fun <T> GodotArray<T>.asList(): List<Variant> = List(size().toInt()) { get(it.toLong()) }

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/TestOne.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/TestOne.kt
@@ -1,10 +1,12 @@
 @file:OptIn(ExperimentalForeignApi::class)
 
+import io.github.kingg22.godot.api.annotations.ExportMethod
 import io.github.kingg22.godot.api.annotations.Godot
 import io.github.kingg22.godot.api.builtin.Callable
 import io.github.kingg22.godot.api.builtin.Vector2
 import io.github.kingg22.godot.api.builtin.Vector2i
 import io.github.kingg22.godot.api.builtin.toGodotString
+import io.github.kingg22.godot.api.builtin.toStringName
 import io.github.kingg22.godot.api.builtin.toVariant
 import io.github.kingg22.godot.api.core.Node
 import io.github.kingg22.godot.api.core.SceneTree
@@ -43,6 +45,9 @@ private const val SPRITE_COUNT = 5
     init {
         GD.print("A new SpriteBench was created with pointer ${nativePtr.rawValue}")
     }
+
+    @ExportMethod
+    fun addTwo(a: Int, b: Int): Int = a + b
 
     override fun _ready() {
         try {
@@ -97,6 +102,12 @@ private const val SPRITE_COUNT = 5
             returnVariant = callable2.call(15L.toVariant())
             println(
                 "[SpriteBench] Callable2 returned: ${returnVariant.stringify().toKString()}, is nil: ${returnVariant.isNil()}, value: ${returnVariant.toIntOrNull()}",
+            )
+
+            println("[SpriteBench] calling @ExportMethod addTwo(3, 4) via Object.call")
+            val addTwoResult = call("addTwo".toStringName(), 3.toVariant(), 4.toVariant())
+            println(
+                "[SpriteBench] addTwo returned: ${addTwoResult.toIntOrNull()} (expected 7)",
             )
         } catch (e: Throwable) {
             println("[SpriteBench] === _ready failed ===")

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/TestOne.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/TestOne.kt
@@ -9,6 +9,7 @@ import io.github.kingg22.godot.api.builtin.toGodotString
 import io.github.kingg22.godot.api.builtin.toStringName
 import io.github.kingg22.godot.api.builtin.toVariant
 import io.github.kingg22.godot.api.core.Node
+import io.github.kingg22.godot.api.core.Object
 import io.github.kingg22.godot.api.core.SceneTree
 import io.github.kingg22.godot.api.core.node.Node2D
 import io.github.kingg22.godot.api.core.node.TextEdit
@@ -122,9 +123,7 @@ private const val SPRITE_COUNT = 5
             if (currentFrame >= START_FRAME) {
                 if (frameIndex == FRAME_COUNT) {
                     println("[SpriteBench] Frame count reached, freeing children")
-                    for (child in getChildren().asList()) {
-                        Node(child.toObject().rawPtr).queueFree()
-                    }
+                    val _ = getChildren().map(Callable { child: Object -> Node(child.rawPtr).queueFree() })
 
                     val outText = StringBuilder(FRAME_COUNT * 12)
                     for (t in frameTimes) {

--- a/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/TestOne.kt
+++ b/mi-juego-prueba/kotlin_native_game/source/src/nativeMain/kotlin/TestOne.kt
@@ -9,7 +9,6 @@ import io.github.kingg22.godot.api.builtin.toGodotString
 import io.github.kingg22.godot.api.builtin.toStringName
 import io.github.kingg22.godot.api.builtin.toVariant
 import io.github.kingg22.godot.api.core.Node
-import io.github.kingg22.godot.api.core.Object
 import io.github.kingg22.godot.api.core.SceneTree
 import io.github.kingg22.godot.api.core.node.Node2D
 import io.github.kingg22.godot.api.core.node.TextEdit
@@ -123,7 +122,10 @@ private const val SPRITE_COUNT = 5
             if (currentFrame >= START_FRAME) {
                 if (frameIndex == FRAME_COUNT) {
                     println("[SpriteBench] Frame count reached, freeing children")
-                    val _ = getChildren().map(Callable { child: Object -> Node(child.rawPtr).queueFree() })
+                    val children = getChildren()
+                    for (i in 0 until children.size()) {
+                        Node(children[i].toObject().rawPtr).queueFree()
+                    }
 
                     val outText = StringBuilder(FRAME_COUNT * 12)
                     for (t in frameTimes) {

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt
@@ -117,7 +117,8 @@ class KogotProcessor(environment: SymbolProcessorEnvironment) : SymbolProcessor 
                                     "'${returnType.qualifiedName}'",
                             location = DiagnosticLocation(classInfo.filePath, classInfo.lineNumber, 0),
                             help = "Supported types: primitives (Int, Float, String, etc.) and Godot builtin types",
-                            note = "This method will not be registered",
+                            note = "This is a compile error: binding generation is aborted for the whole " +
+                                "build until it's fixed",
                         ),
                     )
                 }
@@ -133,7 +134,8 @@ class KogotProcessor(environment: SymbolProcessorEnvironment) : SymbolProcessor 
                                 location = DiagnosticLocation(classInfo.filePath, classInfo.lineNumber, 0),
                                 help =
                                     "Supported types: primitives (Int, Float, String, etc.) and Godot builtin types",
-                                note = "This method will not be registered",
+                                note = "This is a compile error: binding generation is aborted for the whole " +
+                                "build until it's fixed",
                             ),
                         )
                     }
@@ -147,7 +149,8 @@ class KogotProcessor(environment: SymbolProcessorEnvironment) : SymbolProcessor 
                                         "default value, which is not supported yet",
                                 location = DiagnosticLocation(classInfo.filePath, classInfo.lineNumber, 0),
                                 help = "Remove the default value or call this method without @ExportMethod",
-                                note = "This method will not be registered",
+                                note = "This is a compile error: binding generation is aborted for the whole " +
+                                "build until it's fixed",
                             ),
                         )
                     }

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt
@@ -18,6 +18,7 @@ import io.github.kingg22.kogot.processor.ksp.toClassInfo
 import io.github.kingg22.kogot.processor.model.ClassInfo
 import io.github.kingg22.kogot.processor.model.GodotPrimitives
 import io.github.kingg22.kogot.processor.model.TypeInfo
+import io.github.kingg22.kogot.processor.model.getExportedMethods
 import io.github.kingg22.kogot.processor.model.getExportedProperties
 import io.github.kingg22.kogot.processor.model.isGodotBuiltin
 
@@ -102,6 +103,54 @@ class KogotProcessor(environment: SymbolProcessorEnvironment) : SymbolProcessor 
                             note = "This property will not appear in the Inspector",
                         ),
                     )
+                }
+            }
+
+            for (function in classInfo.getExportedMethods()) {
+                val returnType = function.returnType
+                if (returnType != null && !isValidExportType(returnType)) {
+                    diagnostics.add(
+                        DiagnosticMessage.error(
+                            code = DiagnosticCode.INVALID_EXPORT_METHOD_TYPE,
+                            message =
+                                "@ExportMethod '${function.name}' has unsupported return type " +
+                                    "'${returnType.qualifiedName}'",
+                            location = DiagnosticLocation(classInfo.filePath, classInfo.lineNumber, 0),
+                            help = "Supported types: primitives (Int, Float, String, etc.) and Godot builtin types",
+                            note = "This method will not be registered",
+                        ),
+                    )
+                }
+
+                for (parameter in function.parameters) {
+                    if (!isValidExportType(parameter.type)) {
+                        diagnostics.add(
+                            DiagnosticMessage.error(
+                                code = DiagnosticCode.INVALID_EXPORT_METHOD_TYPE,
+                                message =
+                                    "@ExportMethod '${function.name}' has unsupported parameter type " +
+                                        "'${parameter.type.qualifiedName}' for '${parameter.name}'",
+                                location = DiagnosticLocation(classInfo.filePath, classInfo.lineNumber, 0),
+                                help =
+                                    "Supported types: primitives (Int, Float, String, etc.) and Godot builtin types",
+                                note = "This method will not be registered",
+                            ),
+                        )
+                    }
+
+                    if (parameter.hasDefaultValue) {
+                        diagnostics.add(
+                            DiagnosticMessage.error(
+                                code = DiagnosticCode.UNSUPPORTED_METHOD_DEFAULT_ARGUMENT,
+                                message =
+                                    "@ExportMethod '${function.name}' parameter '${parameter.name}' has a " +
+                                        "default value, which is not supported yet",
+                                location = DiagnosticLocation(classInfo.filePath, classInfo.lineNumber, 0),
+                                help = "Remove the default value or call this method without @ExportMethod",
+                                note = "This method will not be registered",
+                            ),
+                        )
+                    }
                 }
             }
         }

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticCode.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/diagnostics/DiagnosticCode.kt
@@ -7,6 +7,8 @@ package io.github.kingg22.kogot.processor.diagnostics
 data class DiagnosticCode(val code: String) {
     companion object {
         val INVALID_EXPORT_TYPE = DiagnosticCode("KOGOT-101")
+        val INVALID_EXPORT_METHOD_TYPE = DiagnosticCode("KOGOT-102")
+        val UNSUPPORTED_METHOD_DEFAULT_ARGUMENT = DiagnosticCode("KOGOT-103")
         val GENERATION_FAILED = DiagnosticCode("KOGOT-201")
     }
 

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generators/kotlin/Constants.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generators/kotlin/Constants.kt
@@ -20,6 +20,7 @@ val C_VALUE = MemberName(K_CINTEROP_PKG, "cValue")
 val AS_STABLE_REF = MemberName(K_CINTEROP_PKG, "asStableRef", true)
 val POINTED = MemberName(K_CINTEROP_PKG, "pointed", true)
 val POINTED_VALUE = MemberName(K_CINTEROP_PKG, "value", true)
+val CINTEROP_GET = MemberName(K_CINTEROP_PKG, "get", true)
 
 val ObjectBindingClassName = ClassName(GODOT_INTERNAL_BINDING_PKG, "ObjectBinding")
 val BindingProcAddressHolderClassName = ClassName(GODOT_INTERNAL_BINDING_PKG, "BindingProcAddressHolder")

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generators/kotlin/GodotBindingGenerator.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generators/kotlin/GodotBindingGenerator.kt
@@ -14,7 +14,9 @@ import io.github.kingg22.kogot.processor.diagnostics.DiagnosticLocation
 import io.github.kingg22.kogot.processor.diagnostics.DiagnosticMessage
 import io.github.kingg22.kogot.processor.model.AnnotationInfo
 import io.github.kingg22.kogot.processor.model.ClassInfo
+import io.github.kingg22.kogot.processor.model.FunctionInfo
 import io.github.kingg22.kogot.processor.model.PropertyInfo
+import io.github.kingg22.kogot.processor.model.getExportedMethods
 import io.github.kingg22.kogot.processor.model.getParentClassShortName
 import io.github.kingg22.kogot.processor.model.getRegisterSignalAnnotation
 import io.github.kingg22.kogot.processor.model.hasExport
@@ -226,6 +228,17 @@ class GodotBindingGenerator(private val typeResolver: VariantTypeResolver = Defa
             )
         }
 
+        /*
+         Add method registrations
+         */
+        val exportedMethods = classInfo.getExportedMethods()
+        for (function in exportedMethods) {
+            val trampolineName = "_godot_call_${function.name}"
+            val trampolineProperty = generateMethodInvocationTrampoline(trampolineName, function, classType)
+            typeSpecBuilder.addProperty(trampolineProperty)
+            funSpec.addCode(buildRegisterMethodCode(classInfo, function, trampolineName))
+        }
+
         typeSpecBuilder.addFunction(funSpec.build())
     }
 
@@ -332,6 +345,135 @@ class GodotBindingGenerator(private val typeResolver: VariantTypeResolver = Defa
             .builder(trampolineName, GDExtensionClassMethodCall, KModifier.PRIVATE)
             .initializer(initializer)
             .build()
+    }
+
+    /**
+     * Generates a `GDExtensionClassMethodCall` trampoline for an `@ExportMethod`-annotated function:
+     * reads each argument out of the `args` array as a `Variant`, calls the real user method, and (if it
+     * has a return value) writes the result back. Mirrors [generateGetterMethodTrampoline] /
+     * [generateSetterMethodTrampoline] but generalized to N arguments.
+     */
+    private fun generateMethodInvocationTrampoline(
+        trampolineName: String,
+        function: FunctionInfo,
+        classType: ClassName,
+    ): PropertySpec {
+        val builder = CodeBlock
+            .builder()
+            .beginControlFlow("%M { _, instancePtr, args, _, returnValue, rError ->", STATIC_C_FUNCTION)
+            .addStatement("val obj = instancePtr.%M<%T>()", GET_INSTANCE_PTR, classType)
+
+        if (function.parameters.isNotEmpty()) {
+            builder
+                .beginControlFlow("if (args == null)")
+                .addStatement(
+                    "rError.%M(%T.%N, 0)",
+                    CallErrorWritePtr,
+                    GDExtensionCallErrorType,
+                    "GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT",
+                )
+                .addStatement("return@%M", STATIC_C_FUNCTION)
+                .endControlFlow()
+        }
+
+        val argNames = function.parameters.mapIndexed { index, parameter ->
+            val variantType = typeResolver.resolve(parameter.type.qualifiedName)
+            val kotlinType = typeResolver.toKotlinPoetType(variantType)
+            val argName = "arg$index"
+
+            builder
+                .addStatement("val rawArg$index = args.%M(${index}L)", CINTEROP_GET)
+                .beginControlFlow("if (rawArg$index == null)")
+                .addStatement(
+                    "rError.%M(%T.%N, %L)",
+                    CallErrorWritePtr,
+                    GDExtensionCallErrorType,
+                    "GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT",
+                    index,
+                )
+                .addStatement("return@%M", STATIC_C_FUNCTION)
+                .endControlFlow()
+                .addStatement(
+                    "val %L = %T(rawArg$index).%M<%T>()",
+                    argName,
+                    VARIANT_CLASS_NAME,
+                    VARIANT_GET_VALUE_OR_NULL,
+                    kotlinType,
+                )
+                .withIndent {
+                    beginControlFlow("?: run")
+                        .addStatement(
+                            "rError.%M(%T.%N, %L)",
+                            CallErrorWritePtr,
+                            GDExtensionCallErrorType,
+                            "GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT",
+                            index,
+                        )
+                        .addStatement("return@%M", STATIC_C_FUNCTION)
+                    endControlFlow()
+                }
+
+            argName
+        }
+
+        val callFormat = "obj.%N(${argNames.joinToString(", ")})"
+        if (function.returnType != null) {
+            builder
+                .addStatement("val result = $callFormat", function.name)
+                .beginControlFlow("if (returnValue != null)")
+                .addStatement("%T.newCopyRaw(returnValue, result.%M().rawPtr)", VARIANT_BINDING, TO_VARIANT)
+                .endControlFlow()
+        } else {
+            builder.addStatement(callFormat, function.name)
+        }
+
+        val initializer = builder
+            .addStatement("rError.%M()", CallErrorWritePtr)
+            .endControlFlow()
+            .build()
+
+        return PropertySpec
+            .builder(trampolineName, GDExtensionClassMethodCall, KModifier.PRIVATE)
+            .initializer(initializer)
+            .build()
+    }
+
+    /** Builds the `registerMethod(...)` call for an `@ExportMethod`-annotated function. */
+    private fun buildRegisterMethodCode(
+        classInfo: ClassInfo,
+        function: FunctionInfo,
+        trampolineName: String,
+    ): CodeBlock {
+        val builder = CodeBlock.builder()
+        builder.addStatement("%M(⇥", REGISTER_METHOD)
+        builder.addStatement("%S,", classInfo.shortName)
+        builder.addStatement("%S,", function.name)
+
+        val hasReturnValue = function.returnType != null
+        val returnVariantType = function.returnType?.let { typeResolver.resolve(it.qualifiedName) } ?: "NIL"
+        builder.addStatement("hasReturnValue = %L,", hasReturnValue)
+        builder.addStatement("returnType = %T.%L,", VARIANT_TYPE_CLASS_NAME, returnVariantType)
+
+        if (function.parameters.isEmpty()) {
+            builder.addStatement("arguments = emptyList(),")
+        } else {
+            builder.addStatement("arguments = listOf(⇥")
+            for (parameter in function.parameters) {
+                val variantType = typeResolver.resolve(parameter.type.qualifiedName)
+                builder.addStatement(
+                    "%T(%T.%L, %S),",
+                    METHOD_ARGUMENT_CLASS_NAME,
+                    VARIANT_TYPE_CLASS_NAME,
+                    variantType,
+                    parameter.name,
+                )
+            }
+            builder.addStatement("⇤),")
+        }
+
+        builder.addStatement("callFunction = %N,", trampolineName)
+        builder.addStatement("⇤)")
+        return builder.build()
     }
 
     private fun buildRegisterSignalAnnotationCode(prop: PropertyInfo, annotation: AnnotationInfo): CodeBlock {

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generators/kotlin/GodotBindingGenerator.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/generators/kotlin/GodotBindingGenerator.kt
@@ -360,17 +360,21 @@ class GodotBindingGenerator(private val typeResolver: VariantTypeResolver = Defa
     ): PropertySpec {
         val builder = CodeBlock
             .builder()
-            .beginControlFlow("%M { _, instancePtr, args, _, returnValue, rError ->", STATIC_C_FUNCTION)
+            .beginControlFlow("%M { _, instancePtr, args, argCount, returnValue, rError ->", STATIC_C_FUNCTION)
             .addStatement("val obj = instancePtr.%M<%T>()", GET_INSTANCE_PTR, classType)
 
         if (function.parameters.isNotEmpty()) {
+            val expected = function.parameters.size
             builder
-                .beginControlFlow("if (args == null)")
+                .beginControlFlow("if (args == null || argCount != ${expected}L)")
                 .addStatement(
-                    "rError.%M(%T.%N, 0)",
+                    "rError.%M(if (argCount < ${expected}L) %T.%N else %T.%N, argCount.toInt(), %L)",
                     CallErrorWritePtr,
                     GDExtensionCallErrorType,
-                    "GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT",
+                    "GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS",
+                    GDExtensionCallErrorType,
+                    "GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS",
+                    expected,
                 )
                 .addStatement("return@%M", STATIC_C_FUNCTION)
                 .endControlFlow()

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/model/ClassInfo.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/model/ClassInfo.kt
@@ -40,6 +40,11 @@ fun ClassInfo.getExportedProperties(): List<PropertyInfo> = properties.filter { 
 fun ClassInfo.getRpcFunctions(): List<FunctionInfo> = functions.filter { it.hasRpc() }
 
 /**
+ * Returns all functions exported via @ExportMethod (callable from GDScript/the editor).
+ */
+fun ClassInfo.getExportedMethods(): List<FunctionInfo> = functions.filter { it.hasExportMethod() }
+
+/**
  * Checks if this class inherits from Node (directly or transitively).
  */
 fun ClassInfo.inheritsFromNode(): Boolean =

--- a/processor/src/main/kotlin/io/github/kingg22/kogot/processor/model/FunctionInfo.kt
+++ b/processor/src/main/kotlin/io/github/kingg22/kogot/processor/model/FunctionInfo.kt
@@ -34,3 +34,17 @@ fun FunctionInfo.isValidRpcTarget(): Boolean {
     // RPC functions cannot have out parameters (we don't track out specifically here, but void return is expected)
     return returnType != null
 }
+
+/**
+ * Returns true if this function has @ExportMethod annotation.
+ */
+fun FunctionInfo.hasExportMethod(): Boolean = annotations.any {
+    it.shortName == "ExportMethod" || it.matches("io.github.kingg22.godot.api.annotations.ExportMethod")
+}
+
+/**
+ * Returns the @ExportMethod annotation or null if not present.
+ */
+fun FunctionInfo.getExportMethodAnnotation(): AnnotationInfo? = annotations.find {
+    it.shortName == "ExportMethod" || it.matches("io.github.kingg22.godot.api.annotations.ExportMethod")
+}


### PR DESCRIPTION
## Summary by Sourcery

Agregar soporte para registrar e invocar métodos personalizados de Kotlin en Godot mediante una nueva anotación @ExportMethod y enlaces en tiempo de ejecución.

Nuevas características:
- Introducir la anotación @ExportMethod para exponer funciones de Kotlin como métodos invocables desde GDScript y otras APIs de Godot.
- Registrar las funciones @ExportMethod en el generador de bindings de Godot, incluyendo trampolines de llamada generados dinámicamente para el marshalling de argumentos/valores de retorno.
- Validar los tipos de parámetros y retorno de @ExportMethod durante el procesamiento y emitir diagnósticos para tipos no compatibles o argumentos por defecto no admitidos.

Mejoras:
- Alinear el manejo de retornos de contenedores (arrays/dictionaries) en el codegen de Kotlin/Native con los tipos integrados, construyendo y pasando contenedores preasignados.
- Refinar la lógica de las expresiones de argumentos de retorno para distinguir retornos de clases del motor de los retornos de colecciones y tipos integrados.

Tests:
- Ampliar el juego de ejemplo de Kotlin/Native para demostrar el uso de @ExportMethod y su invocación mediante Object.call().

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for registering and invoking custom Kotlin methods in Godot via a new @ExportMethod annotation and runtime bindings.

New Features:
- Introduce @ExportMethod annotation to expose Kotlin functions as callable methods from GDScript and other Godot APIs.
- Register @ExportMethod functions in the Godot binding generator, including dynamically generated call trampolines for argument/return marshalling.
- Validate @ExportMethod parameter and return types during processing and emit diagnostics for unsupported types or default arguments.

Enhancements:
- Align container return handling (arrays/dictionaries) in the Kotlin/Native codegen with builtin types by constructing and passing pre-allocated containers.
- Refine return argument expression logic to distinguish engine-class returns from collection and builtin returns.

Tests:
- Extend the sample Kotlin/Native game to demonstrate @ExportMethod usage and invocation via Object.call().

</details>