### PR TITLE
test(gradle plugin): add unit, mock and TestKit coverage for plugin and settings-plugin

### DIFF
--- a/gradle-plugin/README.md
+++ b/gradle-plugin/README.md
@@ -82,3 +82,17 @@ cd gradle-plugin
 ./gradlew build
 ./gradlew publishToMavenLocal   # to consume from a local kogot-based project
 ```
+
+Both `plugin` and `settings-plugin` declare two [JVM test suites](https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html), the Gradle-recommended way to organize plugin tests (see [Gradle's own sample](https://docs.gradle.org/current/samples/sample_testing_gradle_plugins.html)):
+
+| Suite | Run with | What it covers |
+|---|---|---|
+| `test` | `./gradlew test` | Unit tests (JUnit 5, mostly against [`ProjectBuilder`](https://docs.gradle.org/current/javadoc/org/gradle/testfixtures/ProjectBuilder.html)-built projects) and MockK-based mock tests that isolate logic which would otherwise need a real Kotlin/Native target (e.g. `KogotPlugin.wireDependencies`'s KSP-configuration wiring). |
+| `functionalTest` | `./gradlew functionalTest` (also wired into `check`) | [TestKit](https://docs.gradle.org/current/userguide/test_kit.html) (`GradleRunner`) tests that apply the plugin in a real, separate Gradle build. Plugins are applied by bare id with no version: `gradlePlugin.testSourceSets` makes `withPluginClasspath()` inject each module's own runtime classpath (Kotlin Gradle Plugin, KSP Gradle plugin, KotlinPoet, this plugin's classes), so plugin resolution needs no network access. |
+
+Neither suite ever declares a real Kotlin/Native target (`linuxX64()`, etc.) - doing so would need a downloaded Konan toolchain just to run a fast test. `KogotPluginTest`/`KogotPluginFunctionalTest` cover the plugin's behavior with zero declared targets (which is enough to exercise every branch except the per-target KSP wiring, covered separately with mocks by `KogotPluginWireDependenciesTest`), and `KogotSettingsPluginFunctionalTest` relies on `org.gradle.configureondemand=true` so listing tasks on the *main* module never configures (and toolchain-downloads for) the generated `:app:export` companion project.
+
+```bash
+./gradlew test              # unit + mock tests only, fast
+./gradlew check             # test + functionalTest + validatePlugins
+```

--- a/gradle-plugin/plugin/build.gradle.kts
+++ b/gradle-plugin/plugin/build.gradle.kts
@@ -25,8 +25,6 @@ dependencies {
 
     // Used to generate the @CName entry point instead of hand-built strings.
     implementation(libs.kotlinpoet)
-
-    testImplementation(libs.junit)
 }
 
 kotlin {
@@ -42,9 +40,43 @@ java {
     }
 }
 
+// JVM Test Suites (https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html): the
+// Gradle-recommended way to declare test source sets. "test" holds unit + MockK-based mock tests
+// (ProjectBuilder, no full Gradle invocation); "functionalTest" holds TestKit (GradleRunner) tests
+// that apply the plugin in a real, separate Gradle build. Mirrors Gradle's own sample for testing
+// plugins: https://docs.gradle.org/current/samples/sample_testing_gradle_plugins.html
+@Suppress("UnstableApiUsage")
+testing {
+    suites {
+        getByName<JvmTestSuite>("test") {
+            useJUnitJupiter(libs.versions.junit5.get())
+            dependencies {
+                implementation(libs.mockk)
+            }
+        }
+
+        register<JvmTestSuite>("functionalTest") {
+            useJUnitJupiter(libs.versions.junit5.get())
+            dependencies {
+                implementation(project())
+                implementation(gradleTestKit())
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(tasks.named("test"))
+                    }
+                }
+            }
+        }
+    }
+}
+
 gradlePlugin {
     website.set(property("WEBSITE").toString())
     vcsUrl.set(property("VCS_URL").toString())
+    testSourceSets.add(sourceSets["functionalTest"])
 
     plugins {
         create(property("ID").toString()) {
@@ -56,6 +88,10 @@ gradlePlugin {
             tags.set(listOf("godot", "gdextension", "kotlin-native", "kogot"))
         }
     }
+}
+
+tasks.named("check") {
+    dependsOn(testing.suites.named("functionalTest"))
 }
 
 tasks.register("setupPluginUploadFromEnvironment") {

--- a/gradle-plugin/plugin/src/functionalTest/kotlin/io/github/kingg22/kogot/gradle/KogotPluginFunctionalTest.kt
+++ b/gradle-plugin/plugin/src/functionalTest/kotlin/io/github/kingg22/kogot/gradle/KogotPluginFunctionalTest.kt
@@ -1,0 +1,101 @@
+package io.github.kingg22.kogot.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * TestKit functional tests: black-box, running `io.github.kingg22.kogot` through a real, separate
+ * Gradle build (via [GradleRunner]) rather than through [ProjectBuilder][org.gradle.testfixtures.ProjectBuilder].
+ * `settings.gradle.kts`/`build.gradle.kts` in the sample project apply plugins by bare id, with no
+ * version and no plugin repository - `gradlePlugin.testSourceSets` (see plugin/build.gradle.kts)
+ * makes `GradleRunner.withPluginClasspath()` inject this module's own runtime classpath (Kotlin
+ * Gradle Plugin, KSP Gradle plugin, KotlinPoet, and this plugin's own classes) into the sample build,
+ * so plugin resolution needs no network access.
+ *
+ * No native target (`linuxX64()`, etc.) is declared anywhere here, on purpose: see [KogotPluginTest]'s
+ * class doc for why.
+ */
+class KogotPluginFunctionalTest {
+    @TempDir
+    lateinit var projectDir: File
+
+    @BeforeEach
+    fun setUp() {
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            rootProject.name = "sample"
+            """.trimIndent(),
+        )
+    }
+
+    private fun runner(vararg arguments: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments(*arguments, "--stacktrace")
+
+    private fun writeBuildScript(kogotBlock: String = "") {
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                id("org.jetbrains.kotlin.multiplatform")
+                id("io.github.kingg22.kogot")
+            }
+
+            kogot {
+                $kogotBlock
+            }
+
+            tasks.register("printAppliedPlugins") {
+                doLast {
+                    println("KSP_APPLIED=" + project.plugins.hasPlugin("com.google.devtools.ksp"))
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `applying the plugin registers the godot CLI, copy-aggregator and gdextension tasks`() {
+        writeBuildScript()
+
+        val result = runner("tasks", "--all").build()
+
+        assertTrue(result.output.contains(KogotConventions.RUN_GODOT_TASK_NAME), result.output)
+        assertTrue(result.output.contains(KogotConventions.TEST_GODOT_TASK_NAME), result.output)
+        assertTrue(result.output.contains(KogotConventions.COPY_ALL_TASK_NAME), result.output)
+        assertTrue(result.output.contains(KogotConventions.GDEXTENSION_TASK_NAME), result.output)
+    }
+
+    @Test
+    fun `generateGdextensionFile set to false skips registering the gdextension task`() {
+        writeBuildScript(kogotBlock = "generateGdextensionFile.set(false)")
+
+        val result = runner("tasks", "--all").build()
+
+        assertFalse(result.output.contains(KogotConventions.GDEXTENSION_TASK_NAME), result.output)
+    }
+
+    @Test
+    fun `autoApplyKsp true auto-applies the KSP plugin`() {
+        writeBuildScript()
+
+        val result = runner("printAppliedPlugins").build()
+
+        assertTrue(result.output.contains("KSP_APPLIED=true"), result.output)
+    }
+
+    @Test
+    fun `autoApplyKsp false leaves the KSP plugin unapplied`() {
+        writeBuildScript(kogotBlock = "autoApplyKsp.set(false)")
+
+        val result = runner("printAppliedPlugins").build()
+
+        assertTrue(result.output.contains("KSP_APPLIED=false"), result.output)
+    }
+}

--- a/gradle-plugin/plugin/src/main/kotlin/io/github/kingg22/kogot/gradle/KogotPlugin.kt
+++ b/gradle-plugin/plugin/src/main/kotlin/io/github/kingg22/kogot/gradle/KogotPlugin.kt
@@ -41,7 +41,9 @@ abstract class KogotPlugin : Plugin<Project> {
         }
     }
 
-    private fun wireDependencies(
+    // internal (not private): lets the "test" source set unit/mock-test this in isolation, same
+    // convention as KogotTaskRegistration.kt's internal top-level functions.
+    internal fun wireDependencies(
         project: Project,
         extension: KogotExtension,
         kotlin: KotlinMultiplatformExtension,

--- a/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/KogotConventionsTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/KogotConventionsTest.kt
@@ -1,0 +1,60 @@
+package io.github.kingg22.kogot.gradle
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KogotConventionsTest {
+    @Test
+    fun `kspConfigurationName capitalizes only the first character of the target name`() {
+        assertEquals("kspLinuxX64", KogotConventions.kspConfigurationName("linuxX64"))
+        assertEquals("kspX64", KogotConventions.kspConfigurationName("x64"))
+    }
+
+    @Test
+    fun `entryPointTaskName follows the generateKogotEntryPoint naming template`() {
+        assertEquals(
+            "generateKogotEntryPointLinuxX64",
+            KogotConventions.entryPointTaskName("linuxX64"),
+        )
+    }
+
+    @Test
+    fun `copyBinaryTaskName capitalizes both the target and build type`() {
+        assertEquals(
+            "copyKogotBinaryLinuxX64Debug",
+            KogotConventions.copyBinaryTaskName("linuxX64", "debug"),
+        )
+        assertEquals(
+            "copyKogotBinaryMacosArm64Release",
+            KogotConventions.copyBinaryTaskName("macosArm64", "release"),
+        )
+    }
+
+    @Test
+    fun `entryPointOutputDir is nested under generated slash kogot slash entrypoint per target`() {
+        assertEquals("generated/kogot/entrypoint/linuxX64", KogotConventions.entryPointOutputDir("linuxX64"))
+    }
+
+    @Test
+    fun `binaryRelativePath joins output dir, target and build type in order`() {
+        assertEquals("bin/linuxX64/debug", KogotConventions.binaryRelativePath("bin", "linuxX64", "debug"))
+    }
+
+    @Test
+    fun `gdextensionResPath prefixes a res colon slash slash path`() {
+        assertEquals(
+            "res://bin/linuxX64/debug/libgame.so",
+            KogotConventions.gdextensionResPath("bin", "linuxX64", "debug", "libgame.so"),
+        )
+    }
+
+    @Test
+    fun `gdextensionFileName appends the gdextension extension to the library base name`() {
+        assertEquals("mygame.gdextension", KogotConventions.gdextensionFileName("mygame"))
+    }
+
+    @Test
+    fun `godot executable candidates are checked godot4 before godot`() {
+        assertEquals(listOf("godot4", "godot"), KogotConventions.GODOT_EXECUTABLE_CANDIDATES)
+    }
+}

--- a/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/KogotExtensionTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/KogotExtensionTest.kt
@@ -1,0 +1,129 @@
+package io.github.kingg22.kogot.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Unit tests for [KogotExtension]'s defaults and its `gradle.properties` fallback wiring (see
+ * [KogotConventions] for every key). Uses [ProjectBuilder] instead of a full build: `gradle.properties`
+ * placed in the project directory before the project is built is picked up by
+ * `providers.gradleProperty(...)` exactly like a real build would.
+ */
+class KogotExtensionTest {
+    @TempDir
+    lateinit var projectDir: File
+
+    private fun extensionWithProperties(vararg properties: Pair<String, String>): KogotExtension {
+        if (properties.isNotEmpty()) {
+            File(projectDir, "gradle.properties").writeText(
+                properties.joinToString("\n") { (key, value) -> "$key=$value" },
+            )
+        }
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).withName("my-game").build()
+        return project.extensions.create(EXTENSION_NAME, KogotExtension::class.java, project)
+    }
+
+    @Test
+    fun `defaults match KogotConventions when no gradle properties are set`() {
+        val extension = extensionWithProperties()
+
+        assertEquals(KogotConventions.DEFAULT_KOGOT_VERSION, extension.kogotVersion.get())
+        assertEquals(KogotConventions.DEFAULT_KOGOT_GROUP, extension.kogotGroup.get())
+        assertTrue(extension.autoApplyKsp.get())
+        assertTrue(extension.autoAddDependencies.get())
+        assertEquals(KogotConventions.DEFAULT_GODOT_VERSION, extension.godotVersion.get())
+        assertEquals(KogotConventions.DEFAULT_ENTRY_SYMBOL, extension.entrySymbol.get())
+        assertEquals(KogotConventions.DEFAULT_ENTRY_POINT_PACKAGE, extension.entryPointPackage.get())
+        assertTrue(extension.generateEntryPoint.get())
+        assertTrue(extension.generateGdextensionFile.get())
+        assertEquals(KogotConventions.DEFAULT_RUNTIME_PACKAGE, extension.runtimePackage.get())
+        assertEquals(KogotConventions.DEFAULT_BINARY_OUTPUT_DIR, extension.binaryOutputDir.get())
+        assertEquals(KogotConventions.DEFAULT_MIN_INITIALIZATION_LEVEL, extension.minInitializationLevel.get())
+        assertFalse(extension.reloadable.get())
+        assertFalse(extension.androidAarPlugin.get())
+        assertTrue(extension.icons.get().isEmpty())
+        assertTrue(extension.gdextensionDependencies.get().isEmpty())
+        assertTrue(extension.godotCliArgs.get().isEmpty())
+        assertFalse(extension.compatibilityMaximum.isPresent)
+        assertFalse(extension.godotProjectDir.isPresent)
+        assertEquals(
+            KogotConventions.DEFAULT_GENERATED_BINDINGS_PACKAGE,
+            extension.generatedBindingsPackage.get(),
+        )
+        assertEquals(
+            KogotConventions.DEFAULT_GENERATED_BINDINGS_CLASS_NAME,
+            extension.generatedBindingsClassName.get(),
+        )
+    }
+
+    @Test
+    fun `libraryBaseName falls back to the Gradle project name`() {
+        val extension = extensionWithProperties()
+        assertEquals("my-game", extension.libraryBaseName.get())
+    }
+
+    @Test
+    fun `every gradle properties key overrides its matching extension property`() {
+        val godotProjectDir = File(projectDir, "godot-project").apply { mkdirs() }
+        val extension = extensionWithProperties(
+            KogotConventions.PROP_KOGOT_VERSION to "9.9.9",
+            KogotConventions.PROP_KOGOT_GROUP to "com.example.custom",
+            KogotConventions.PROP_AUTO_APPLY_KSP to "false",
+            KogotConventions.PROP_AUTO_ADD_DEPENDENCIES to "false",
+            KogotConventions.PROP_GODOT_VERSION to "4.3.0",
+            KogotConventions.PROP_GODOT_PROJECT_DIR to godotProjectDir.absolutePath,
+            KogotConventions.PROP_ENTRY_SYMBOL to "custom_entry",
+            KogotConventions.PROP_ENTRY_POINT_PACKAGE to "com.example.entry",
+            KogotConventions.PROP_GENERATE_ENTRY_POINT to "false",
+            KogotConventions.PROP_GENERATE_GDEXTENSION_FILE to "false",
+            KogotConventions.PROP_RUNTIME_PACKAGE to "com.example.runtime",
+            KogotConventions.PROP_BINARY_OUTPUT_DIR to "out",
+            KogotConventions.PROP_MIN_INITIALIZATION_LEVEL to "GDEXTENSION_INITIALIZATION_CORE",
+            KogotConventions.PROP_LIBRARY_BASE_NAME to "custom_base_name",
+            KogotConventions.PROP_COMPATIBILITY_MAXIMUM to "4.5.0",
+            KogotConventions.PROP_RELOADABLE to "true",
+            KogotConventions.PROP_ANDROID_AAR_PLUGIN to "true",
+            KogotConventions.PROP_GENERATED_BINDINGS_PACKAGE to "com.example.generated",
+            KogotConventions.PROP_GENERATED_BINDINGS_CLASS_NAME to "CustomGeneratedBindings",
+        )
+
+        assertEquals("9.9.9", extension.kogotVersion.get())
+        assertEquals("com.example.custom", extension.kogotGroup.get())
+        assertFalse(extension.autoApplyKsp.get())
+        assertFalse(extension.autoAddDependencies.get())
+        assertEquals("4.3.0", extension.godotVersion.get())
+        assertEquals(godotProjectDir, extension.godotProjectDir.get().asFile)
+        assertEquals("custom_entry", extension.entrySymbol.get())
+        assertEquals("com.example.entry", extension.entryPointPackage.get())
+        assertFalse(extension.generateEntryPoint.get())
+        assertFalse(extension.generateGdextensionFile.get())
+        assertEquals("com.example.runtime", extension.runtimePackage.get())
+        assertEquals("out", extension.binaryOutputDir.get())
+        assertEquals("GDEXTENSION_INITIALIZATION_CORE", extension.minInitializationLevel.get())
+        assertEquals("custom_base_name", extension.libraryBaseName.get())
+        assertEquals("4.5.0", extension.compatibilityMaximum.get())
+        assertTrue(extension.reloadable.get())
+        assertTrue(extension.androidAarPlugin.get())
+        assertEquals("com.example.generated", extension.generatedBindingsPackage.get())
+        assertEquals("CustomGeneratedBindings", extension.generatedBindingsClassName.get())
+    }
+
+    @Test
+    fun `explicit godotExecutable gradle property wins over PATH auto-detection`() {
+        val fakeExecutable = File(projectDir, "godot4").apply {
+            writeText("#!/bin/sh\n")
+            setExecutable(true)
+        }
+        val extension = extensionWithProperties(
+            KogotConventions.PROP_GODOT_EXECUTABLE to fakeExecutable.absolutePath,
+        )
+
+        assertEquals(fakeExecutable.absolutePath, extension.godotExecutable.get().asFile.absolutePath)
+    }
+}

--- a/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/KogotPluginTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/KogotPluginTest.kt
@@ -1,0 +1,87 @@
+package io.github.kingg22.kogot.gradle
+
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests exercising [KogotPlugin.apply] against a real (but native-target-free) Kotlin
+ * Multiplatform project built with [ProjectBuilder]. No `linuxX64()`/`macosArm64()` target is ever
+ * declared here on purpose: declaring one triggers Kotlin/Native toolchain resolution (a multi-hundred
+ * MB download the first time), which has no place in a fast unit test. That target-dependent branch
+ * of the plugin (KSP-configuration wiring per [org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget])
+ * is covered instead by [KogotPluginWireDependenciesTest] with mocked targets, and end-to-end by the
+ * `functionalTest` suite.
+ *
+ * `afterEvaluate` never fires on its own for a [ProjectBuilder] project, so tests call
+ * [ProjectInternal.evaluate] explicitly to trigger it - the standard technique for unit-testing
+ * Gradle plugins that defer work to `afterEvaluate`.
+ */
+class KogotPluginTest {
+    private fun evaluatedProject(configure: KogotExtension.() -> Unit = {}): org.gradle.api.Project {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
+        project.pluginManager.apply(KogotPlugin::class.java)
+        project.extensions.getByType(KogotExtension::class.java).configure()
+        (project as ProjectInternal).evaluate()
+        return project
+    }
+
+    @Test
+    fun `registers the kogot extension`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(KogotPlugin::class.java)
+
+        assertNotNull(project.extensions.findByName(EXTENSION_NAME))
+        assertTrue(project.extensions.findByName(EXTENSION_NAME) is KogotExtension)
+    }
+
+    @Test
+    fun `does nothing beyond registering the extension when the KMP plugin is never applied`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(KogotPlugin::class.java)
+        (project as ProjectInternal).evaluate()
+
+        assertNull(project.tasks.findByName(KogotConventions.RUN_GODOT_TASK_NAME))
+        assertNull(project.tasks.findByName(KogotConventions.GDEXTENSION_TASK_NAME))
+    }
+
+    @Test
+    fun `registers the godot CLI and copy-aggregator tasks once the KMP plugin is applied`() {
+        val project = evaluatedProject()
+
+        assertNotNull(project.tasks.findByName(KogotConventions.RUN_GODOT_TASK_NAME))
+        assertNotNull(project.tasks.findByName(KogotConventions.TEST_GODOT_TASK_NAME))
+        assertNotNull(project.tasks.findByName(KogotConventions.COPY_ALL_TASK_NAME))
+        // generateGdextensionFile defaults to true.
+        assertNotNull(project.tasks.findByName(KogotConventions.GDEXTENSION_TASK_NAME))
+    }
+
+    @Test
+    fun `no entry-point task is registered when there are no native targets`() {
+        val project = evaluatedProject()
+        assertTrue(project.tasks.filter { it.name.startsWith("generateKogotEntryPoint") }.isEmpty())
+    }
+
+    @Test
+    fun `generateGdextensionFile set to false skips registering the gdextension task`() {
+        val project = evaluatedProject { generateGdextensionFile.set(false) }
+        assertNull(project.tasks.findByName(KogotConventions.GDEXTENSION_TASK_NAME))
+    }
+
+    @Test
+    fun `autoApplyKsp applies the KSP plugin automatically`() {
+        val project = evaluatedProject()
+        assertTrue(project.plugins.hasPlugin(KogotConventions.KSP_PLUGIN_ID))
+    }
+
+    @Test
+    fun `autoApplyKsp set to false leaves the KSP plugin unapplied`() {
+        val project = evaluatedProject { autoApplyKsp.set(false) }
+        assertFalse(project.plugins.hasPlugin(KogotConventions.KSP_PLUGIN_ID))
+    }
+}

--- a/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/KogotPluginWireDependenciesTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/KogotPluginWireDependenciesTest.kt
@@ -1,0 +1,157 @@
+package io.github.kingg22.kogot.gradle
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Mock-based unit tests for [KogotPlugin.wireDependencies]. This isolates its branch logic (which
+ * KSP configuration a native target's processor dependency lands in, and the early-return when KSP
+ * auto-apply is off) from real Kotlin/Native target construction, which would otherwise need a
+ * downloaded Konan toolchain just to obtain a [KotlinNativeTarget] instance - see [KogotPluginTest]'s
+ * class doc for why that's out of scope for a fast unit test.
+ *
+ * [org.gradle.api.Project], [KogotExtension] and every [org.gradle.api.artifacts.Configuration]
+ * involved are real Gradle objects built with [ProjectBuilder] - configurations are simply created
+ * (or not) per scenario, and dependency wiring is asserted on the real [org.gradle.api.artifacts.DependencySet].
+ * Only the Kotlin Multiplatform DSL types that would otherwise require a real KMP target
+ * ([KotlinMultiplatformExtension], [KotlinSourceSet], [KotlinDependencyHandler], [KotlinNativeTarget])
+ * are mocked with MockK.
+ */
+class KogotPluginWireDependenciesTest {
+    private val project = ProjectBuilder.builder().build()
+    private val plugin = project.objects.newInstance(KogotPlugin::class.java)
+    private lateinit var extension: KogotExtension
+    private lateinit var kotlin: KotlinMultiplatformExtension
+    private lateinit var sourceSets: NamedDomainObjectContainer<KotlinSourceSet>
+    private lateinit var commonMain: KotlinSourceSet
+    private lateinit var dependencyHandler: KotlinDependencyHandler
+
+    @BeforeEach
+    fun setUp() {
+        extension = project.extensions.create(EXTENSION_NAME, KogotExtension::class.java, project)
+        kotlin = mockk()
+        sourceSets = mockk()
+        commonMain = mockk()
+        dependencyHandler = mockk(relaxed = true)
+
+        every { kotlin.sourceSets } returns sourceSets
+        every {
+            sourceSets.getByName(KogotConventions.COMMON_MAIN_SOURCE_SET, any<Action<KotlinSourceSet>>())
+        } answers {
+            secondArg<Action<KotlinSourceSet>>().execute(commonMain)
+            commonMain
+        }
+        every { commonMain.dependencies(any<KotlinDependencyHandler.() -> Unit>()) } answers {
+            firstArg<KotlinDependencyHandler.() -> Unit>().invoke(dependencyHandler)
+        }
+    }
+
+    private fun nativeTarget(targetName: String): KotlinNativeTarget {
+        val target = mockk<KotlinNativeTarget>()
+        every { target.name } returns targetName
+        return target
+    }
+
+    @Test
+    fun `always wires the commonMain annotations dependency, even with no native targets`() {
+        plugin.wireDependencies(project, extension, kotlin, emptyList())
+
+        verify { dependencyHandler.implementation("io.github.kingg22.kogot:kogot-annotations:0.1.0") }
+    }
+
+    @Test
+    fun `uses the overridden kogotGroup and kogotVersion for the coordinate`() {
+        extension.kogotGroup.set("com.example")
+        extension.kogotVersion.set("9.9.9")
+
+        plugin.wireDependencies(project, extension, kotlin, emptyList())
+
+        verify { dependencyHandler.implementation("com.example:kogot-annotations:9.9.9") }
+    }
+
+    @Test
+    fun `autoApplyKsp false skips wiring the processor dependency entirely`() {
+        extension.autoApplyKsp.set(false)
+        val target = nativeTarget("linuxX64")
+
+        plugin.wireDependencies(project, extension, kotlin, listOf(target))
+
+        assertNull(project.configurations.findByName("kspLinuxX64"))
+        assertNull(project.configurations.findByName(KogotConventions.KSP_COMMON_MAIN_METADATA_CONFIGURATION))
+    }
+
+    @Test
+    fun `adds the processor dependency to the target-specific ksp configuration when present`() {
+        val kspConfig = project.configurations.create("kspLinuxX64")
+        val target = nativeTarget("linuxX64")
+
+        plugin.wireDependencies(project, extension, kotlin, listOf(target))
+
+        val dependency = kspConfig.dependencies.single()
+        assertEquals("io.github.kingg22.kogot", dependency.group)
+        assertEquals("kogot-processor", dependency.name)
+        assertEquals("0.1.0", dependency.version)
+    }
+
+    @Test
+    fun `falls back to kspCommonMainMetadata when the target-specific configuration is absent`() {
+        val metadataConfig = project.configurations.create(KogotConventions.KSP_COMMON_MAIN_METADATA_CONFIGURATION)
+        val target = nativeTarget("linuxX64")
+
+        plugin.wireDependencies(project, extension, kotlin, listOf(target))
+
+        val dependency = metadataConfig.dependencies.single()
+        assertEquals("kogot-processor", dependency.name)
+    }
+
+    @Test
+    fun `prefers the target-specific configuration over the shared metadata one when both exist`() {
+        val kspConfig = project.configurations.create("kspLinuxX64")
+        val metadataConfig = project.configurations.create(KogotConventions.KSP_COMMON_MAIN_METADATA_CONFIGURATION)
+        val target = nativeTarget("linuxX64")
+
+        plugin.wireDependencies(project, extension, kotlin, listOf(target))
+
+        assertEquals(1, kspConfig.dependencies.size)
+        assertTrue(metadataConfig.dependencies.isEmpty())
+    }
+
+    @Test
+    fun `neither configuration present skips the processor dependency without throwing`() {
+        val target = nativeTarget("linuxX64")
+
+        plugin.wireDependencies(project, extension, kotlin, listOf(target))
+
+        assertNull(project.configurations.findByName("kspLinuxX64"))
+        assertNull(project.configurations.findByName(KogotConventions.KSP_COMMON_MAIN_METADATA_CONFIGURATION))
+    }
+
+    @Test
+    fun `wires every native target independently`() {
+        val linux = project.configurations.create("kspLinuxX64")
+        val macos = project.configurations.create("kspMacosArm64")
+
+        plugin.wireDependencies(
+            project,
+            extension,
+            kotlin,
+            listOf(nativeTarget("linuxX64"), nativeTarget("macosArm64")),
+        )
+
+        assertEquals(1, linux.dependencies.size)
+        assertEquals(1, macos.dependencies.size)
+    }
+}

--- a/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/tasks/GenerateEntryPointTaskTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/tasks/GenerateEntryPointTaskTest.kt
@@ -1,0 +1,95 @@
+package io.github.kingg22.kogot.gradle.tasks
+
+import io.github.kingg22.kogot.gradle.KogotConventions
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Unit tests for [GenerateEntryPointTask]'s [GenerateEntryPointTask.generate] action, calling it
+ * directly (no task graph / no Gradle build execution) against a task instance created through
+ * [ProjectBuilder]. Assertions check for individual tokens rather than reconstructing full lines,
+ * since KotlinPoet is free to re-wrap long statements and to use plain identifiers (no import) for
+ * any type that happens to share the file's own package.
+ */
+class GenerateEntryPointTaskTest {
+    @TempDir
+    lateinit var projectDir: File
+
+    private lateinit var task: GenerateEntryPointTask
+    private lateinit var outputDir: File
+
+    @BeforeEach
+    fun setUp() {
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        task = project.tasks.register("generateEntryPointTest", GenerateEntryPointTask::class.java).get()
+        outputDir = File(projectDir, "build/generated").apply { mkdirs() }
+        task.outputDir.set(outputDir)
+    }
+
+    private fun generatedFile(packageName: String): File =
+        File(outputDir, packageName.replace('.', '/') + "/KogotEntryPoint.kt")
+
+    @Test
+    fun `generates the CName entry point wired to the default runtime and bindings packages`() {
+        // A package distinct from the default bindings/entry-point package ("generated") so the
+        // generated bindings class reference is guaranteed to need (and show) an import.
+        task.entrySymbol.set("my_game_entry")
+        task.packageName.set("com.example.entry")
+
+        task.generate()
+
+        val content = generatedFile("com.example.entry").readText()
+        assertTrue(content.contains("package com.example.entry"), content)
+        assertTrue(content.contains("@CName(\"my_game_entry\")"), content)
+        assertTrue(content.contains("fun kogotEntryPoint("), content)
+        assertTrue(
+            content.contains(
+                "import ${KogotConventions.DEFAULT_GENERATED_BINDINGS_PACKAGE}." +
+                    KogotConventions.DEFAULT_GENERATED_BINDINGS_CLASS_NAME,
+            ),
+            content,
+        )
+        // "internal" is a Kotlin soft keyword, so KotlinPoet backtick-escapes that path segment
+        // (`godot.\`internal\`.binding...`) - check the distinctive tail instead of the full FQN.
+        assertTrue(content.contains("binding.BindingInitializationCallbacks"), content)
+        assertTrue(content.contains("minimum_initialization_level ="), content)
+        assertTrue(content.contains(KogotConventions.DEFAULT_MIN_INITIALIZATION_LEVEL), content)
+    }
+
+    @Test
+    fun `honors overridden runtime, bindings and initialization level properties`() {
+        task.entrySymbol.set("custom_entry")
+        task.packageName.set("com.example.entry")
+        task.minInitializationLevel.set("GDEXTENSION_INITIALIZATION_CORE")
+        task.runtimePackage.set("com.example.runtime")
+        task.generatedBindingsPackage.set("com.example.generated")
+        task.generatedBindingsClassName.set("CustomBindings")
+
+        task.generate()
+
+        val content = generatedFile("com.example.entry").readText()
+        assertTrue(content.contains("@CName(\"custom_entry\")"), content)
+        assertTrue(content.contains("import com.example.generated.CustomBindings"), content)
+        assertTrue(content.contains("import com.example.runtime.binding.BindingInitializationCallbacks"), content)
+        assertTrue(content.contains("import com.example.runtime.ffi.GDExtensionInitializationLevel"), content)
+        assertTrue(content.contains("minimum_initialization_level ="), content)
+        assertTrue(content.contains("GDEXTENSION_INITIALIZATION_CORE"), content)
+    }
+
+    @Test
+    fun `file is marked generated and not meant to be edited`() {
+        task.entrySymbol.set("entry")
+        task.packageName.set("generated")
+
+        task.generate()
+
+        val content = generatedFile("generated").readText()
+        assertTrue(content.contains("DO NOT EDIT"), content)
+        assertFalse(content.isBlank())
+    }
+}

--- a/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/tasks/GenerateGdextensionTaskTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/tasks/GenerateGdextensionTaskTest.kt
@@ -1,0 +1,152 @@
+package io.github.kingg22.kogot.gradle.tasks
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Unit tests for [GenerateGdextensionTask]. Unlike [GenerateEntryPointTaskTest] this task builds its
+ * output with a plain `buildString` (no KotlinPoet formatting to account for), so exact-content
+ * assertions are safe and are the strongest guard against accidentally reordering or reformatting
+ * the `.gdextension` sections (see the task's class doc: Godot matches `[libraries]` entries in
+ * declaration order, so insertion order must never be silently "fixed" into sorted order).
+ */
+class GenerateGdextensionTaskTest {
+    @TempDir
+    lateinit var projectDir: File
+
+    private lateinit var task: GenerateGdextensionTask
+    private lateinit var outputFile: File
+
+    @BeforeEach
+    fun setUp() {
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        task = project.tasks.register("generateGdextensionTest", GenerateGdextensionTask::class.java).get()
+        outputFile = File(projectDir, "godot-project/game.gdextension")
+        task.outputFile.set(outputFile)
+    }
+
+    @Test
+    fun `minimal configuration omits every optional section`() {
+        task.entrySymbol.set("my_entry")
+        task.libraries.set(linkedMapOf("linux.debug.x86_64" to "res://bin/linuxX64/debug/libgame.so"))
+
+        task.generate()
+
+        val expected = "[configuration]\n" +
+            "entry_symbol = \"my_entry\"\n" +
+            "\n" +
+            "[libraries]\n" +
+            "linux.debug.x86_64 = \"res://bin/linuxX64/debug/libgame.so\"\n"
+
+        assertEquals(expected, outputFile.readText())
+    }
+
+    @Test
+    fun `writes compatibility, reloadable and android_aar_plugin only when set`() {
+        task.entrySymbol.set("my_entry")
+        task.compatibilityMinimum.set("4.7.1")
+        task.reloadable.set(true)
+        task.androidAarPlugin.set(true)
+        task.libraries.set(linkedMapOf("linux.debug.x86_64" to "res://bin/linuxX64/debug/libgame.so"))
+        // compatibilityMaximum left unset on purpose.
+
+        task.generate()
+
+        val expected = "[configuration]\n" +
+            "entry_symbol = \"my_entry\"\n" +
+            "compatibility_minimum = \"4.7.1\"\n" +
+            "reloadable = true\n" +
+            "android_aar_plugin = true\n" +
+            "\n" +
+            "[libraries]\n" +
+            "linux.debug.x86_64 = \"res://bin/linuxX64/debug/libgame.so\"\n"
+
+        assertEquals(expected, outputFile.readText())
+    }
+
+    @Test
+    fun `preserves libraries insertion order rather than sorting`() {
+        task.entrySymbol.set("my_entry")
+        task.libraries.set(
+            linkedMapOf(
+                "windows.debug.x86_64" to "res://bin/mingwX64/debug/libgame.dll",
+                "linux.debug.x86_64" to "res://bin/linuxX64/debug/libgame.so",
+            ),
+        )
+
+        task.generate()
+
+        val librariesSection = outputFile.readText().substringAfter("[libraries]\n")
+        val order = librariesSection.lines().filter { it.isNotBlank() }
+        assertEquals(
+            listOf(
+                "windows.debug.x86_64 = \"res://bin/mingwX64/debug/libgame.dll\"",
+                "linux.debug.x86_64 = \"res://bin/linuxX64/debug/libgame.so\"",
+            ),
+            order,
+        )
+    }
+
+    @Test
+    fun `writes icons section only when icons are configured`() {
+        task.entrySymbol.set("my_entry")
+        task.libraries.set(linkedMapOf("linux.debug.x86_64" to "res://bin/linuxX64/debug/libgame.so"))
+        task.icons.set(linkedMapOf("OtherNode" to "res://icons/other_node.svg", "MyNode" to "res://icons/my_node.svg"))
+
+        task.generate()
+
+        val expected = "[configuration]\n" +
+            "entry_symbol = \"my_entry\"\n" +
+            "\n" +
+            "[libraries]\n" +
+            "linux.debug.x86_64 = \"res://bin/linuxX64/debug/libgame.so\"\n" +
+            "\n" +
+            "[icons]\n" +
+            "OtherNode = \"res://icons/other_node.svg\"\n" +
+            "MyNode = \"res://icons/my_node.svg\"\n"
+
+        assertEquals(expected, outputFile.readText())
+    }
+
+    @Test
+    fun `formats dependencies with a trailing comma on every row but the last`() {
+        task.entrySymbol.set("my_entry")
+        task.libraries.set(linkedMapOf("linux.debug.x86_64" to "res://bin/linuxX64/debug/libgame.so"))
+        task.dependencies.set(
+            linkedMapOf(
+                "linux.x86_64" to linkedMapOf("libs/liba.so" to "bin", "libs/libb.so" to "bin"),
+            ),
+        )
+
+        task.generate()
+
+        val expected = "[configuration]\n" +
+            "entry_symbol = \"my_entry\"\n" +
+            "\n" +
+            "[libraries]\n" +
+            "linux.debug.x86_64 = \"res://bin/linuxX64/debug/libgame.so\"\n" +
+            "\n" +
+            "[dependencies]\n" +
+            "linux.x86_64 = {\n" +
+            "\"libs/liba.so\" : \"bin\",\n" +
+            "\"libs/libb.so\" : \"bin\"\n" +
+            "}\n"
+
+        assertEquals(expected, outputFile.readText())
+    }
+
+    @Test
+    fun `creates parent directories for the output file`() {
+        task.entrySymbol.set("my_entry")
+        task.libraries.set(emptyMap())
+
+        task.generate()
+
+        assertEquals(true, outputFile.exists())
+        assertEquals(true, outputFile.parentFile.isDirectory)
+    }
+}

--- a/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/tasks/GodotExecTaskTest.kt
+++ b/gradle-plugin/plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/tasks/GodotExecTaskTest.kt
@@ -1,0 +1,111 @@
+package io.github.kingg22.kogot.gradle.tasks
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Unit tests for [GodotExecTask]/[RunGodotTask]/[TestGodotTask]: the CLI argument assembly (read
+ * back from the registered [org.gradle.process.CommandLineArgumentProvider]s, without running any
+ * task graph) and the executable-existence guard in [GodotExecTask.exec]. Never calls `super.exec()`
+ * with a real path — that would spawn an actual OS process, which isn't something a unit test
+ * should depend on (no `godot` binary is available in CI/unit-test environments).
+ */
+class GodotExecTaskTest {
+    @TempDir
+    lateinit var projectDir: File
+
+    private lateinit var godotProjectDir: File
+
+    @BeforeEach
+    fun setUp() {
+        godotProjectDir = File(projectDir, "godot-project").apply { mkdirs() }
+    }
+
+    private fun <T : GodotExecTask> createTask(type: Class<T>): T {
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        return project.tasks.register("execTest", type).get()
+    }
+
+    private fun GodotExecTask.resolvedArgs(): List<String> = argumentProviders.flatMap { it.asArguments() }
+
+    @Test
+    fun `RunGodotTask defaults headless to true when not set explicitly`() {
+        val task = createTask(RunGodotTask::class.java)
+        assertTrue(task.headless.get())
+    }
+
+    @Test
+    fun `arguments always start with --path followed by the godot project directory`() {
+        val task = createTask(RunGodotTask::class.java)
+        task.godotProjectDir.set(godotProjectDir)
+        task.headless.set(false)
+
+        val args = task.resolvedArgs()
+        assertEquals(listOf("--path", godotProjectDir.absolutePath), args)
+    }
+
+    @Test
+    fun `--headless is appended only when headless is true`() {
+        val task = createTask(RunGodotTask::class.java)
+        task.godotProjectDir.set(godotProjectDir)
+        task.headless.set(true)
+
+        assertEquals(listOf("--path", godotProjectDir.absolutePath, "--headless"), task.resolvedArgs())
+    }
+
+    @Test
+    fun `extraArgs are appended after --path and --headless`() {
+        val task = createTask(RunGodotTask::class.java)
+        task.godotProjectDir.set(godotProjectDir)
+        task.headless.set(true)
+        task.extraArgs.set(listOf("--verbose", "--quit"))
+
+        assertEquals(
+            listOf("--path", godotProjectDir.absolutePath, "--headless", "--verbose", "--quit"),
+            task.resolvedArgs(),
+        )
+    }
+
+    @Test
+    fun `TestGodotTask defaults headless to true`() {
+        val task = createTask(TestGodotTask::class.java)
+        assertTrue(task.headless.get())
+    }
+
+    @Test
+    fun `TestGodotTask appends --script only when testScenePath is set`() {
+        val withoutScript = createTask(TestGodotTask::class.java)
+        withoutScript.godotProjectDir.set(godotProjectDir)
+        assertFalse(withoutScript.resolvedArgs().contains("--script"))
+
+        val withScript = createTask(TestGodotTask::class.java)
+        withScript.godotProjectDir.set(godotProjectDir)
+        withScript.testScenePath.set("res://test/run_tests.gd")
+
+        assertEquals(
+            listOf("--path", godotProjectDir.absolutePath, "--headless", "--script", "res://test/run_tests.gd"),
+            withScript.resolvedArgs(),
+        )
+    }
+
+    @Test
+    fun `exec fails fast when the configured godot executable does not exist`() {
+        val task = createTask(RunGodotTask::class.java)
+        task.godotProjectDir.set(godotProjectDir)
+        task.godotExecutable.set(File(projectDir, "does-not-exist"))
+
+        // exec() itself is protected (inherited from Gradle's Exec/AbstractExecTask); go through the
+        // public Task.actions the same way Gradle's own task executor would invoke the @TaskAction method.
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            task.actions.forEach { it.execute(task) }
+        }
+        assertTrue(exception.message.orEmpty().contains("godot executable not found"), exception.message)
+    }
+}

--- a/gradle-plugin/settings-plugin/build.gradle.kts
+++ b/gradle-plugin/settings-plugin/build.gradle.kts
@@ -14,8 +14,6 @@ dependencies {
     implementation(gradleApi())
 
     implementation(libs.kotlinpoet)
-
-    testImplementation(libs.junit)
 }
 
 kotlin {
@@ -31,9 +29,39 @@ java {
     }
 }
 
+// See :plugin's build.gradle.kts for why these two suites exist and what each is for.
+@Suppress("UnstableApiUsage")
+testing {
+    suites {
+        getByName<JvmTestSuite>("test") {
+            useJUnitJupiter(libs.versions.junit5.get())
+            dependencies {
+                implementation(libs.mockk)
+            }
+        }
+
+        register<JvmTestSuite>("functionalTest") {
+            useJUnitJupiter(libs.versions.junit5.get())
+            dependencies {
+                implementation(project())
+                implementation(gradleTestKit())
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(tasks.named("test"))
+                    }
+                }
+            }
+        }
+    }
+}
+
 gradlePlugin {
     website.set(property("WEBSITE").toString())
     vcsUrl.set(property("VCS_URL").toString())
+    testSourceSets.add(sourceSets["functionalTest"])
 
     plugins {
         create("${property("ID")}.settings") {
@@ -47,4 +75,8 @@ gradlePlugin {
             tags.set(listOf("godot", "gdextension", "kotlin-native", "kogot"))
         }
     }
+}
+
+tasks.named("check") {
+    dependsOn(testing.suites.named("functionalTest"))
 }

--- a/gradle-plugin/settings-plugin/build.gradle.kts
+++ b/gradle-plugin/settings-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -56,6 +57,34 @@ testing {
             }
         }
     }
+}
+
+// The generated export companion build.gradle.kts applies io.github.kingg22.kogot (from :plugin),
+// not just io.github.kingg22.kogot.settings - gradlePlugin.testSourceSets only injects *this*
+// module's own runtime classpath, so a functional test that actually configures that companion
+// project (rather than just asserting on its generated text) needs a combined classpath. Built with
+// a second PluginUnderTestMetadata task instance (see https://docs.gradle.org/current/userguide/test_kit.html),
+// the same task type gradlePlugin.testSourceSets wires up automatically, but pointed at a classpath
+// that also includes :plugin.
+val functionalTestExtraPluginClasspath = configurations.create("functionalTestExtraPluginClasspath")
+
+dependencies {
+    functionalTestExtraPluginClasspath(project(":plugin"))
+}
+
+val combinedFunctionalTestPluginClasspath = tasks.register<PluginUnderTestMetadata>(
+    "combinedFunctionalTestPluginClasspath",
+) {
+    pluginClasspath.from(sourceSets.main.get().runtimeClasspath, functionalTestExtraPluginClasspath)
+    outputDirectory.set(layout.buildDirectory.dir("combinedFunctionalTestPluginClasspath"))
+}
+
+tasks.named<Test>("functionalTest") {
+    dependsOn(combinedFunctionalTestPluginClasspath)
+    systemProperty(
+        "combinedPluginClasspathDir",
+        combinedFunctionalTestPluginClasspath.get().outputDirectory.get().asFile.absolutePath,
+    )
 }
 
 gradlePlugin {

--- a/gradle-plugin/settings-plugin/src/functionalTest/kotlin/io/github/kingg22/kogot/gradle/settings/KogotSettingsPluginFunctionalTest.kt
+++ b/gradle-plugin/settings-plugin/src/functionalTest/kotlin/io/github/kingg22/kogot/gradle/settings/KogotSettingsPluginFunctionalTest.kt
@@ -5,25 +5,39 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.util.Properties
 
 /**
  * TestKit functional test for [KogotSettingsPlugin]. `settings.gradle.kts` applies the plugin by
- * bare id, no version - `gradlePlugin.testSourceSets` (see settings-plugin/build.gradle.kts) makes
- * `GradleRunner.withPluginClasspath()` inject this module's runtime classpath into the sample build,
- * so it also has `NativeTargetPreset`/`KogotBuildType` available for the settings script to import.
+ * bare id, no version. The generated companion project's build script additionally applies
+ * `io.github.kingg22.kogot` (from `:plugin`), which `gradlePlugin.testSourceSets`' automatic
+ * classpath injection (`GradleRunner.withPluginClasspath()`) doesn't cover on its own - see
+ * [combinedPluginClasspath] and settings-plugin/build.gradle.kts's `combinedFunctionalTestPluginClasspath`
+ * task for how both plugins' classpaths get combined for this test.
  *
  * `org.gradle.configureondemand=true` is set on purpose: without it, a plain `gradle :app:tasks`
- * still configures *every* included project by default, including the generated `:app:export`
- * companion project, which declares a real `linuxX64()` native target and would trigger a
- * Kotlin/Native toolchain download - see [io.github.kingg22.kogot.gradle.KogotPluginTest]'s class doc
- * for why that has no place in a fast test. Configuration-on-demand keeps `:app:export` unconfigured
- * as long as no requested task actually needs its task graph, letting this test verify the eager,
- * settings-evaluation-time side effects (project inclusion, generated build script, task
- * registration) without paying for a full companion-project build.
+ * would also configure the generated `:app:export` companion project even though nothing requested
+ * depends on it. The first two tests below rely on that to stay fast (only `:app` gets configured);
+ * the third explicitly targets `:app:export` instead, to prove the generated script is not just
+ * textually plausible but actually loadable and appliable by Gradle - see
+ * [io.github.kingg22.kogot.gradle.KogotPluginTest]'s class doc for why that target still declares no
+ * real Kotlin/Native target (avoiding a Konan toolchain download).
  */
 class KogotSettingsPluginFunctionalTest {
     @TempDir
     lateinit var rootDir: File
+
+    /**
+     * `:plugin` + `:settings-plugin`'s combined runtime classpath, written by the
+     * `combinedFunctionalTestPluginClasspath` task (settings-plugin/build.gradle.kts) into the
+     * directory named by the `combinedPluginClasspathDir` system property.
+     */
+    private val combinedPluginClasspath: List<File> by lazy {
+        val metadataFile =
+            File(System.getProperty("combinedPluginClasspathDir"), "plugin-under-test-metadata.properties")
+        val properties = Properties().apply { metadataFile.inputStream().use(::load) }
+        properties.getProperty("implementation-classpath").split(File.pathSeparator).map(::File)
+    }
 
     private fun writeSettings(kogotBlock: String) {
         File(rootDir, "gradle.properties").writeText("org.gradle.configureondemand=true\n")
@@ -50,7 +64,7 @@ class KogotSettingsPluginFunctionalTest {
     private fun runner(vararg arguments: String): GradleRunner =
         GradleRunner.create()
             .withProjectDir(rootDir)
-            .withPluginClasspath()
+            .withPluginClasspath(combinedPluginClasspath)
             .withArguments(*arguments, "--stacktrace")
 
     @Test
@@ -86,5 +100,24 @@ class KogotSettingsPluginFunctionalTest {
         val result = runner(":app:tasks", "--all").build()
 
         assertTrue(result.output.contains("kogotExport"), result.output)
+    }
+
+    @Test
+    fun `the generated companion project actually configures and registers kogot's own tasks`() {
+        writeSettings(
+            """
+            export(":app") {
+                targets = listOf(NativeTargetPreset.LINUX_X64)
+            }
+            """.trimIndent(),
+        )
+
+        // Unlike the other two tests, this forces :app:export itself to configure - proving the
+        // generated build script actually applies org.jetbrains.kotlin.multiplatform and
+        // io.github.kingg22.kogot successfully, not just that its text looks right.
+        val result = runner(":app:export:tasks", "--all").build()
+
+        assertTrue(result.output.contains("runGodot"), result.output)
+        assertTrue(result.output.contains("generateKogotGdextension"), result.output)
     }
 }

--- a/gradle-plugin/settings-plugin/src/functionalTest/kotlin/io/github/kingg22/kogot/gradle/settings/KogotSettingsPluginFunctionalTest.kt
+++ b/gradle-plugin/settings-plugin/src/functionalTest/kotlin/io/github/kingg22/kogot/gradle/settings/KogotSettingsPluginFunctionalTest.kt
@@ -1,0 +1,90 @@
+package io.github.kingg22.kogot.gradle.settings
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * TestKit functional test for [KogotSettingsPlugin]. `settings.gradle.kts` applies the plugin by
+ * bare id, no version - `gradlePlugin.testSourceSets` (see settings-plugin/build.gradle.kts) makes
+ * `GradleRunner.withPluginClasspath()` inject this module's runtime classpath into the sample build,
+ * so it also has `NativeTargetPreset`/`KogotBuildType` available for the settings script to import.
+ *
+ * `org.gradle.configureondemand=true` is set on purpose: without it, a plain `gradle :app:tasks`
+ * still configures *every* included project by default, including the generated `:app:export`
+ * companion project, which declares a real `linuxX64()` native target and would trigger a
+ * Kotlin/Native toolchain download - see [io.github.kingg22.kogot.gradle.KogotPluginTest]'s class doc
+ * for why that has no place in a fast test. Configuration-on-demand keeps `:app:export` unconfigured
+ * as long as no requested task actually needs its task graph, letting this test verify the eager,
+ * settings-evaluation-time side effects (project inclusion, generated build script, task
+ * registration) without paying for a full companion-project build.
+ */
+class KogotSettingsPluginFunctionalTest {
+    @TempDir
+    lateinit var rootDir: File
+
+    private fun writeSettings(kogotBlock: String) {
+        File(rootDir, "gradle.properties").writeText("org.gradle.configureondemand=true\n")
+        File(rootDir, "app").mkdirs()
+        File(rootDir, "settings.gradle.kts").writeText(
+            """
+            import io.github.kingg22.kogot.gradle.settings.NativeTargetPreset
+
+            plugins {
+                id("io.github.kingg22.kogot.settings")
+            }
+
+            rootProject.name = "sample-root"
+
+            include(":app")
+
+            kogot {
+                $kogotBlock
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun runner(vararg arguments: String): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(rootDir)
+            .withPluginClasspath()
+            .withArguments(*arguments, "--stacktrace")
+
+    @Test
+    fun `export includes a companion project and generates its build script on disk`() {
+        writeSettings(
+            """
+            export(":app") {
+                targets = listOf(NativeTargetPreset.LINUX_X64)
+            }
+            """.trimIndent(),
+        )
+
+        runner(":app:tasks", "--all").build()
+
+        val generatedScript = File(rootDir, "app/build/kogot-export/build.gradle.kts")
+        assertTrue(generatedScript.isFile, "expected $generatedScript to have been generated")
+
+        val content = generatedScript.readText()
+        assertTrue(content.contains("id(\"io.github.kingg22.kogot\")"), content)
+        assertTrue(content.contains("linuxX64"), content)
+    }
+
+    @Test
+    fun `kogotExport is registered on the exporting module as a proxy task`() {
+        writeSettings(
+            """
+            export(":app") {
+                targets = listOf(NativeTargetPreset.LINUX_X64)
+            }
+            """.trimIndent(),
+        )
+
+        val result = runner(":app:tasks", "--all").build()
+
+        assertTrue(result.output.contains("kogotExport"), result.output)
+    }
+}

--- a/gradle-plugin/settings-plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/settings/ExportBuildScriptGeneratorTest.kt
+++ b/gradle-plugin/settings-plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/settings/ExportBuildScriptGeneratorTest.kt
@@ -1,0 +1,123 @@
+package io.github.kingg22.kogot.gradle.settings
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Tests [generateExportBuildScript]'s output. Assertions check for individual tokens rather than
+ * reconstructing full lines, since KotlinPoet is free to re-wrap long statements (e.g. a control-flow
+ * header with a long `listOf(...)` argument) at any space once a line nears its column limit.
+ */
+class ExportBuildScriptGeneratorTest {
+    @Test
+    fun `throws when the spec declares no targets`() {
+        val spec = KogotExportSpec(":app")
+
+        val exception = assertThrows(IllegalArgumentException::class.java) { generateExportBuildScript(spec) }
+        assertTrue(exception.message.orEmpty().contains(":app"), exception.message)
+    }
+
+    @Test
+    fun `minimal spec applies both plugins and only the required kogot and kotlin settings`() {
+        val spec = KogotExportSpec(":app").apply { targets = listOf(NativeTargetPreset.LINUX_X64) }
+
+        val content = generateExportBuildScript(spec).toString()
+
+        assertTrue(content.contains("DO NOT EDIT"), content)
+        assertTrue(content.contains(":app"), content)
+        assertTrue(content.contains("id(\"org.jetbrains.kotlin.multiplatform\")"), content)
+        assertTrue(content.contains("id(\"io.github.kingg22.kogot\")"), content)
+        assertTrue(content.contains("autoApplyKsp.set(false)"), content)
+        assertTrue(content.contains("autoAddDependencies.set(false)"), content)
+        assertTrue(content.contains("generateEntryPoint.set(true)"), content)
+        assertTrue(content.contains("libraryBaseName.set(\"app\")"), content)
+        assertTrue(content.contains("implementation(project(\":app\"))"), content)
+        assertTrue(content.contains("applyDefaultHierarchyTemplate()"), content)
+        assertTrue(content.contains("linuxX64"), content)
+        assertTrue(content.contains("binaries"), content)
+        assertTrue(content.contains("sharedLib(buildTypes = listOf("), content)
+        assertTrue(content.contains("NativeBuildType.DEBUG"), content)
+        assertTrue(content.contains("baseName = \"app\""), content)
+
+        assertFalse(content.contains("entrySymbol.set("), content)
+        assertFalse(content.contains("godotVersion.set("), content)
+        assertFalse(content.contains("godotProjectDir.set("), content)
+        assertFalse(content.contains("generatedBindingsPackage.set("), content)
+        assertFalse(content.contains("generatedBindingsClassName.set("), content)
+        assertFalse(content.contains("generateGdextensionFile.set("), content)
+    }
+
+    @Test
+    fun `libraryBaseName is derived from the last segment of a nested module path`() {
+        val spec = KogotExportSpec(":games:app").apply { targets = listOf(NativeTargetPreset.LINUX_X64) }
+
+        val content = generateExportBuildScript(spec).toString()
+
+        assertTrue(content.contains("libraryBaseName.set(\"app\")"), content)
+        assertTrue(content.contains("implementation(project(\":games:app\"))"), content)
+    }
+
+    @Test
+    fun `explicit libraryBaseName overrides the derived one`() {
+        val spec = KogotExportSpec(":app").apply {
+            targets = listOf(NativeTargetPreset.LINUX_X64)
+            libraryBaseName = "my_game"
+        }
+
+        val content = generateExportBuildScript(spec).toString()
+
+        assertTrue(content.contains("libraryBaseName.set(\"my_game\")"), content)
+        assertTrue(content.contains("baseName = \"my_game\""), content)
+    }
+
+    @Test
+    fun `every optional field renders its own set call when configured`() {
+        val projectDirFile = File("/godot/my-project")
+        val spec = KogotExportSpec(":app").apply {
+            targets = listOf(NativeTargetPreset.LINUX_X64)
+            entrySymbol = "custom_entry"
+            godotVersion = "4.7.1"
+            godotProjectDir = projectDirFile
+            generatedBindingsPackage = "com.example.generated"
+            generatedBindingsClassName = "CustomBindings"
+            generateGdextensionFile = false
+        }
+
+        val content = generateExportBuildScript(spec).toString()
+
+        assertTrue(content.contains("entrySymbol.set(\"custom_entry\")"), content)
+        assertTrue(content.contains("godotVersion.set(\"4.7.1\")"), content)
+        assertTrue(content.contains("godotProjectDir.set(file("), content)
+        assertTrue(content.contains(projectDirFile.absolutePath), content)
+        assertTrue(content.contains("generatedBindingsPackage.set(\"com.example.generated\")"), content)
+        assertTrue(content.contains("generatedBindingsClassName.set(\"CustomBindings\")"), content)
+        assertTrue(content.contains("generateGdextensionFile.set(false)"), content)
+    }
+
+    @Test
+    fun `multiple targets each get their own binaries block`() {
+        val spec = KogotExportSpec(":app").apply {
+            targets = listOf(NativeTargetPreset.LINUX_X64, NativeTargetPreset.MACOS_ARM64)
+            buildTypes = listOf(KogotBuildType.DEBUG, KogotBuildType.RELEASE)
+        }
+
+        val content = generateExportBuildScript(spec).toString()
+
+        assertTrue(content.contains("linuxX64"), content)
+        assertTrue(content.contains("macosArm64"), content)
+        assertTrue(content.contains("NativeBuildType.DEBUG"), content)
+        assertTrue(content.contains("NativeBuildType.RELEASE"), content)
+    }
+
+    @Test
+    fun `does not apply this monorepo's own build-logic convention plugins`() {
+        val spec = KogotExportSpec(":app").apply { targets = listOf(NativeTargetPreset.LINUX_X64) }
+
+        val content = generateExportBuildScript(spec).toString()
+
+        assertFalse(content.contains("buildlogic."), content)
+    }
+}

--- a/gradle-plugin/settings-plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/settings/KogotExportSpecTest.kt
+++ b/gradle-plugin/settings-plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/settings/KogotExportSpecTest.kt
@@ -1,0 +1,67 @@
+package io.github.kingg22.kogot.gradle.settings
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class KogotExportSpecTest {
+    @Test
+    fun `defaults are export, no targets, debug-only, and every optional field unset`() {
+        val spec = KogotExportSpec(":app")
+
+        assertEquals(":app", spec.modulePath)
+        assertEquals("export", spec.exportProjectName)
+        assertTrue(spec.targets.isEmpty())
+        assertEquals(listOf(KogotBuildType.DEBUG), spec.buildTypes)
+        assertNull(spec.entrySymbol)
+        assertNull(spec.godotVersion)
+        assertNull(spec.godotProjectDir)
+        assertNull(spec.libraryBaseName)
+        assertNull(spec.generatedBindingsPackage)
+        assertNull(spec.generatedBindingsClassName)
+        assertNull(spec.generateGdextensionFile)
+    }
+
+    @Test
+    fun `exportProjectDir defaults to rootDir slash modulePath slash build slash kogot-export`() {
+        val spec = KogotExportSpec(":app")
+        val rootDir = File("/settings-root")
+
+        assertEquals(File("/settings-root/app/build/kogot-export"), spec.exportProjectDir(rootDir))
+    }
+
+    @Test
+    fun `exportProjectDir strips only the leading colon and replaces remaining colons with slashes`() {
+        val spec = KogotExportSpec(":games:app")
+        val rootDir = File("/settings-root")
+
+        assertEquals(File("/settings-root/games/app/build/kogot-export"), spec.exportProjectDir(rootDir))
+    }
+
+    @Test
+    fun `fields are mutable for the export DSL block`() {
+        val spec = KogotExportSpec(":app").apply {
+            exportProjectName = "custom-export"
+            targets = listOf(NativeTargetPreset.LINUX_X64, NativeTargetPreset.MACOS_ARM64)
+            buildTypes = listOf(KogotBuildType.DEBUG, KogotBuildType.RELEASE)
+            entrySymbol = "custom_entry"
+            godotVersion = "4.7.1"
+            libraryBaseName = "my_game"
+            generatedBindingsPackage = "com.example.generated"
+            generatedBindingsClassName = "CustomBindings"
+            generateGdextensionFile = false
+        }
+
+        assertEquals("custom-export", spec.exportProjectName)
+        assertEquals(listOf(NativeTargetPreset.LINUX_X64, NativeTargetPreset.MACOS_ARM64), spec.targets)
+        assertEquals(listOf(KogotBuildType.DEBUG, KogotBuildType.RELEASE), spec.buildTypes)
+        assertEquals("custom_entry", spec.entrySymbol)
+        assertEquals("4.7.1", spec.godotVersion)
+        assertEquals("my_game", spec.libraryBaseName)
+        assertEquals("com.example.generated", spec.generatedBindingsPackage)
+        assertEquals("CustomBindings", spec.generatedBindingsClassName)
+        assertEquals(false, spec.generateGdextensionFile)
+    }
+}

--- a/gradle-plugin/settings-plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/settings/KogotSettingsExtensionTest.kt
+++ b/gradle-plugin/settings-plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/settings/KogotSettingsExtensionTest.kt
@@ -1,0 +1,52 @@
+package io.github.kingg22.kogot.gradle.settings
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * [KogotSettingsExtension.exports] is `internal`; this test lives in the module's own `test` source
+ * set, which the Kotlin Gradle Plugin compiles as a friend module of `main` by default, so the
+ * internal accessor is visible here without needing to widen its visibility for testing.
+ */
+class KogotSettingsExtensionTest {
+    @Test
+    fun `export with no configuration block registers a spec with defaults`() {
+        val extension = TestKogotSettingsExtension()
+
+        extension.export(":app")
+
+        val spec = extension.exports.single()
+        assertEquals(":app", spec.modulePath)
+        assertTrue(spec.targets.isEmpty())
+    }
+
+    @Test
+    fun `export applies the configuration block to the created spec`() {
+        val extension = TestKogotSettingsExtension()
+
+        extension.export(":app") {
+            it.targets = listOf(NativeTargetPreset.LINUX_X64)
+            it.libraryBaseName = "my_game"
+        }
+
+        val spec = extension.exports.single()
+        assertEquals(listOf(NativeTargetPreset.LINUX_X64), spec.targets)
+        assertEquals("my_game", spec.libraryBaseName)
+    }
+
+    @Test
+    fun `multiple export calls accumulate independent specs`() {
+        val extension = TestKogotSettingsExtension()
+
+        extension.export(":app") { it.libraryBaseName = "app_game" }
+        extension.export(":tools:editor") { it.libraryBaseName = "editor_tool" }
+
+        assertEquals(2, extension.exports.size)
+        assertEquals(listOf(":app", ":tools:editor"), extension.exports.map { it.modulePath })
+        assertEquals(listOf("app_game", "editor_tool"), extension.exports.map { it.libraryBaseName })
+    }
+}
+
+/** [KogotSettingsExtension] is `abstract` only for Gradle's own decoration; safe to instantiate directly in tests. */
+private class TestKogotSettingsExtension : KogotSettingsExtension()

--- a/gradle-plugin/settings-plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/settings/NativeTargetPresetTest.kt
+++ b/gradle-plugin/settings-plugin/src/test/kotlin/io/github/kingg22/kogot/gradle/settings/NativeTargetPresetTest.kt
@@ -1,0 +1,32 @@
+package io.github.kingg22.kogot.gradle.settings
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NativeTargetPresetTest {
+    @Test
+    fun `dslName matches the Kotlin Gradle Plugin target function name for every preset`() {
+        assertEquals("linuxX64", NativeTargetPreset.LINUX_X64.dslName)
+        assertEquals("linuxArm64", NativeTargetPreset.LINUX_ARM64.dslName)
+        assertEquals("macosX64", NativeTargetPreset.MACOS_X64.dslName)
+        assertEquals("macosArm64", NativeTargetPreset.MACOS_ARM64.dslName)
+        assertEquals("mingwX64", NativeTargetPreset.MINGW_X64.dslName)
+        assertEquals("iosArm64", NativeTargetPreset.IOS_ARM64.dslName)
+        assertEquals("iosX64", NativeTargetPreset.IOS_X64.dslName)
+        assertEquals("iosSimulatorArm64", NativeTargetPreset.IOS_SIMULATOR_ARM64.dslName)
+    }
+
+    @Test
+    fun `every enum constant has a unique dslName`() {
+        val dslNames = NativeTargetPreset.entries.map { it.dslName }
+        assertEquals(dslNames.size, dslNames.toSet().size)
+    }
+}
+
+class KogotBuildTypeTest {
+    @Test
+    fun `dslName matches NativeBuildType constant names`() {
+        assertEquals("DEBUG", KogotBuildType.DEBUG.dslName)
+        assertEquals("RELEASE", KogotBuildType.RELEASE.dslName)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,14 @@ gradle-plugin-publish = "2.1.1"
 
 # https://github.com/junit-team/junit4/releases
 junit = "4.13.2"
+# https://github.com/junit-team/junit5/releases
+# Named "junit5", not "junit-jupiter", to avoid colliding with the "junit" (JUnit 4) catalog
+# accessor: a nested "junit.jupiter" accessor would otherwise force "junit" itself behind
+# ".asProvider()".
+junit5 = "5.14.3"
+
+# https://github.com/mockk/mockk/releases
+mockk = "1.14.11"
 
 # https://github.com/uber/NullAway/releases
 nullaway = "0.13.8"
@@ -102,6 +110,7 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler-proces
 androidx-room-compiler-testing = { group = "androidx.room", name = "room-compiler-processing-testing", version.ref = "androidx-room-compiler" }
 google-truth = { group = "com.google.truth", name = "truth", version.ref = "google-truth" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 # build-logic
 apache-commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "apache-commons-compress" }


### PR DESCRIPTION
## Summary

- Adds two [JVM Test Suites](https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html) (Gradle's recommended setup for testing plugins) to both `gradle-plugin/plugin` and `gradle-plugin/settings-plugin`: `test` (JUnit 5 + MockK, run with `./gradlew test`) and `functionalTest` (Gradle TestKit, wired into `check`).
- **Unit tests**: `KogotConventions`' naming/path templates, `KogotExtension`'s defaults and full `gradle.properties` fallback matrix (via `ProjectBuilder`), `GenerateEntryPointTask`/`GenerateGdextensionTask`'s generated output, `GodotExecTask`/`RunGodotTask`/`TestGodotTask`'s CLI argument assembly and executable-guard, `KogotPlugin`'s task registration and KSP auto-apply (KMP applied with zero native targets, so no Kotlin/Native toolchain download is needed), and the settings-plugin's pure logic (`ExportBuildScriptGenerator`, `KogotExportSpec`, `KogotSettingsExtension`, the target/build-type enums).
- **Mock tests**: `KogotPluginWireDependenciesTest` uses MockK to isolate `KogotPlugin.wireDependencies`'s branch logic (which KSP configuration a native target's processor dependency lands in, the `kspCommonMainMetadata` fallback, the `autoApplyKsp=false` early return) against mocked Kotlin Multiplatform DSL types, so it doesn't need a real `KotlinNativeTarget` (which would otherwise require downloading the Konan toolchain). `wireDependencies` is widened from `private` to `internal` for this, matching the existing internal-for-testability convention already used in `KogotTaskRegistration.kt`.
- **TestKit functional tests**: `KogotPluginFunctionalTest` and `KogotSettingsPluginFunctionalTest` apply each plugin by bare id (no version) in a real, separate Gradle build via `GradleRunner`; `gradlePlugin.testSourceSets` makes `withPluginClasspath()` inject each module's own runtime classpath, so plugin resolution needs no network access. The settings-plugin test sets `org.gradle.configureondemand=true` so listing tasks on the main module doesn't also configure (and toolchain-download for) the generated `:app:export` companion project.
- Adds `mockk` (1.14.11) and `junit5` (5.14.3, named to avoid a version-catalog accessor collision with the existing `junit` (JUnit 4) entry) to `gradle/libs.versions.toml`, and documents the two suites in `gradle-plugin/README.md`.

No real Kotlin/Native target is declared anywhere in the new tests, by design — see the class docs on `KogotPluginTest`/`KogotPluginFunctionalTest`/`KogotSettingsPluginFunctionalTest` for why.

## Test plan

- [x] `./gradlew test` — unit + mock tests pass for both `:plugin` and `:settings-plugin` (verified locally against a temporarily-bumped JDK 21 toolchain, since this sandbox has no JDK 17 and toolchain auto-provisioning is network-policy-blocked; the toolchain declarations themselves are unchanged at JDK 17 in this PR)
- [x] `./gradlew check` (`test` + `functionalTest` + `validatePlugins`) passes for both modules
- [ ] CI run on JDK 17

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVKDEtewmm8XijKiszugHH)_

## Resumen de Sourcery

Establece una cobertura rápida de pruebas unitarias y pruebas funcionales aisladas para ambos plugins de Gradle sin requerir descargas de la cadena de herramientas de Kotlin/Native.

Mejoras:
- Añade cobertura mediante pruebas unitarias, basadas en mocks y Gradle TestKit para los plugins de Gradle y de configuración, incluidos los valores predeterminados de las extensiones, el comportamiento de las tareas, la configuración de dependencias, las salidas generadas y la lógica de exportación de la configuración.

Compilación:
- Configura suites de pruebas JVM con JUnit 5 y suites de pruebas funcionales con Gradle TestKit para ambos módulos de plugins, con las pruebas funcionales incluidas en `check`.
- Añade dependencias de prueba de JUnit 5 y MockK al catálogo de versiones.

Documentación:
- Documenta las suites de pruebas de los plugins, su cobertura y cómo ejecutarlas en el README del plugin de Gradle.

Pruebas:
- Añade pruebas exhaustivas con ProjectBuilder y MockK sin requerir descargas de la cadena de herramientas de Kotlin/Native.
- Añade pruebas de Gradle TestKit de caja negra que aplican ambos plugins en compilaciones aisladas.

Tareas de mantenimiento:
- Expone la lógica de configuración de dependencias del plugin a nivel de módulo para permitir pruebas aisladas.

<details>
<summary>Original summary in English</summary>

## Resumen de Sourcery

Establecer una cobertura rápida e independiente de la cadena de herramientas para pruebas unitarias, basadas en mocks y funcionales de ambos plugins de Gradle.

Mejoras:
- Añadir una cobertura integral de pruebas unitarias, basadas en mocks y de Gradle TestKit para los plugins de Gradle y de settings, incluido el comportamiento de las extensiones, el registro y los argumentos de las tareas, los archivos generados, la configuración de dependencias y la generación de scripts de exportación.

Build:
- Configurar las suites de pruebas JVM de JUnit 5 y MockK para ambos módulos de plugins, añadir suites funcionales de Gradle TestKit e incluir las pruebas funcionales en `check`.

Documentación:
- Documentar las suites de pruebas de los plugins, la cobertura, los comandos de ejecución y el enfoque de pruebas sin cadena de herramientas de Kotlin/Native.

Pruebas:
- Añadir pruebas aisladas de ProjectBuilder y MockK sin destinos reales de Kotlin/Native, además de pruebas de caja negra con TestKit para aplicar y configurar ambos plugins en compilaciones de Gradle independientes.

Tareas de mantenimiento:
- Exponer la lógica de configuración de dependencias con visibilidad de módulo para realizar pruebas aisladas y añadir las dependencias del catálogo de JUnit 5 y MockK.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Establish fast, toolchain-independent unit, mock, and functional test coverage for both Gradle plugins.

Enhancements:
- Add comprehensive unit, mock-based, and Gradle TestKit coverage for the Gradle and settings plugins, including extension behavior, task registration and arguments, generated files, dependency wiring, and export-script generation.

Build:
- Configure JUnit 5 and MockK JVM test suites for both plugin modules, add Gradle TestKit functional suites, and include functional tests in `check`.

Documentation:
- Document the plugin test suites, coverage, execution commands, and Kotlin/Native toolchain-free testing approach.

Tests:
- Add isolated ProjectBuilder and MockK tests without real Kotlin/Native targets, plus black-box TestKit tests for applying and configuring both plugins in separate Gradle builds.

Chores:
- Expose dependency-wiring logic at module visibility for isolated testing and add JUnit 5 and MockK catalog dependencies.

</details>

</details>