### PR TITLE
fix(codegen): virtual dispatch return support for void*

### DIFF
--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt
@@ -63,6 +63,11 @@ class VirtualCallImplGen(private val typeResolver: TypeResolver) {
         if (returnType == "void") return true
         if (ctx.isNativeStructure(returnType)) return false
         if (returnType == "Variant") return true
+        // extension_api.json only ever uses the plain "void*" string as a return type (unlike argument
+        // types, which also see "const void*") — confirmed against v4_7_1's 3 void*-returning virtuals
+        // (ScriptExtension._instance_create/_placeholder_instance_create,
+        // ScriptLanguageExtension._debug_get_stack_level_instance), so no "const " stripping needed here.
+        if (returnType == "void*") return true
         val kotlinType = typeResolver.resolve(rv)
         return primitiveKotlinToCVar(kotlinType) != null ||
             kotlinType == BOOLEAN ||
@@ -264,6 +269,17 @@ class VirtualCallImplGen(private val typeResolver: TypeResolver) {
 
             ctx.isEngineClass(returnType) -> addStatement(
                 "ret?.%M<%T>()?.%M?.%M = result.rawPtr",
+                cinteropReinterpret,
+                C_OPAQUE_POINTER_VAR,
+                cinteropPointed,
+                cinteropValue,
+            )
+
+            // typeResolver.resolve() maps "void*" directly to COpaquePointer (KotlinNativeTypeResolver
+            // .resolvePointer), so `result` is already the raw pointer value here — same write as the
+            // engine-class branch above, just without unwrapping a `.rawPtr` property first.
+            returnType == "void*" -> addStatement(
+                "ret?.%M<%T>()?.%M?.%M = result",
                 cinteropReinterpret,
                 C_OPAQUE_POINTER_VAR,
                 cinteropPointed,

--- a/docs/notes/issue-137-virtual-dispatch-void-return-plan.md
+++ b/docs/notes/issue-137-virtual-dispatch-void-return-plan.md
@@ -1,0 +1,56 @@
+# Virtual dispatch: void* return support (issue #137)
+
+## Problem
+
+Discovered while implementing [#42](https://github.com/kingg22/kogot/issues/42), same file #135
+fixed. `VirtualCallImplGen.isReturnSupported`
+(`codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt`,
+lines 60-73) has no branch for `returnType == "void*"`. A virtual method whose return type is `void*`
+gets no `GDExtensionClassCallVirtual` trampoline at all: Godot's `get_virtual_func` returns `null` for
+it and silently falls back to its own C++ default (no-op) behavior. The Kotlin override compiles but
+is never called.
+
+`#135`'s outcome section explicitly scoped this out: "`void*` returns (`_instance_create`,
+`_debug_get_stack_level_instance`, ...) remain unsupported, as scoped — out of reach of this mechanism
+(not a builtin placement-construct, no copy constructor to look up)". This note picks that up as its
+own, narrower fix.
+
+Confirmed via `godot-version/v4_7_1/extension_api.json` — exactly 3 virtual methods return `void*`,
+all as the plain string `"void*"` (no `"const void*"` return ever appears in the JSON, unlike
+argument types which do use both forms):
+- `ScriptExtension._instance_create`
+- `ScriptExtension._placeholder_instance_create`
+- `ScriptLanguageExtension._debug_get_stack_level_instance`
+
+Blocks #42 Fase 3: `ScriptExtension._instance_create` needs to actually be invokable so a Kotlin
+`KotlinScript._instanceCreate(forObject: GodotObject): COpaquePointer` override gets called by the
+engine.
+
+## Prior art in the codebase
+
+- `#135` (`docs/notes/issue-135-virtual-dispatch-heap-return-plan.md`) fixed heap-backed builtin
+  returns (String, Dictionary, Variant, ...) via placement-construction into `ret`. `void*` is
+  structurally simpler: no builtin, no copy constructor — just a raw opaque pointer write.
+- The existing `ctx.isEngineClass(returnType)` branch in `buildReturnWrite` already does exactly this
+  shape of write — `ret?.reinterpret<COpaquePointerVar>()?.pointed?.value = result.rawPtr` — for
+  engine-class returns. The only difference for `void*` is that `result` is already the raw
+  `COpaquePointer` (per `KotlinNativeTypeResolver.resolvePointer`, which maps `void*` directly to
+  `COpaquePointer`, confirmed in `KotlinNativeTypeResolverTest.kt`), not a wrapper object with a
+  `.rawPtr` property — so the write is the same minus the `.rawPtr` suffix.
+
+## Scope
+
+1. `isReturnSupported`: add `if (returnType == "void*") return true`, matching the plain-string form
+   confirmed in `extension_api.json` (no `const` prefix stripping needed on the return side, unlike
+   `isArgSupported`'s argument-side check).
+2. `buildReturnWrite`: add a `returnType == "void*"` branch, structurally identical to the
+   `ctx.isEngineClass(returnType)` branch but writing `result` directly instead of `result.rawPtr`.
+3. `isArgSupported`/argument-side `void*` handling is explicitly untouched — out of scope, still
+   unsupported per the type-support matrix in `docs/technical-design/virtual-dispatch.md`.
+4. `ScriptExtension._instance_create` takes one `Object`-typed argument (already supported via the
+   existing `ctx.isEngineClass(arg.type)` branch in `appendArgRead`) and returns `void*` — no other
+   changes to `buildTrampoline`'s arg-read flow are needed for this method shape.
+
+## Outcome
+
+(filled in after implementation + verification)

--- a/docs/notes/issue-137-virtual-dispatch-void-return-plan.md
+++ b/docs/notes/issue-137-virtual-dispatch-void-return-plan.md
@@ -53,4 +53,58 @@ engine.
 
 ## Outcome
 
-(filled in after implementation + verification)
+Implemented as scoped, no surprises:
+
+- `isReturnSupported`: added `if (returnType == "void*") return true` right after the `Variant` check,
+  before the `typeResolver.resolve()` call (unneeded for this branch).
+- `buildReturnWrite`: added a `returnType == "void*"` branch right after the `ctx.isEngineClass`
+  branch, writing `ret?.reinterpret<COpaquePointerVar>()?.pointed?.value = result` — confirmed by
+  reading the generated `ScriptExtensionVirtualCalls.kt` output that `result` (from
+  `typeResolver.resolve()` resolving `void*` to `COpaquePointer`) needs no `.rawPtr` unwrap, unlike the
+  engine-class branch it's modeled on.
+- No changes needed to `buildTrampoline`/`appendArgRead`: `ScriptExtension._instance_create`'s single
+  `Object`-typed argument was already supported via the existing `ctx.isEngineClass(arg.type)` branch.
+
+### Verification (mirroring #135's corrected methodology — real exit codes, no exit-code-masking pipes)
+
+- `:codegen:api:kotlin-native:compileKotlin` — `BUILD SUCCESSFUL`, exit 0.
+- `:codegen:api:kotlin-native:test` + `:codegen:api:common:test` — `BUILD SUCCESSFUL`, exit 0.
+- `:kotlin-native:api:generated:generateGodotKotlinNativeApi` — regenerated the API; confirmed by
+  reading the output directly (this worktree had no prior generated output to diff against, so
+  verified by content inspection instead of a before/after diff):
+  - `ScriptExtensionVirtualCalls.kt` now has `instanceCreate` and `placeholderInstanceCreate`
+    `GDExtensionClassCallVirtual` properties (previously would not exist at all).
+  - `ScriptExtension.kt`'s `_instanceCreate`/`_placeholderInstanceCreate` now carry
+    `@GodotVirtualMethod("_instance_create")` / `@GodotVirtualMethod("_placeholder_instance_create")`.
+  - `ScriptLanguageExtensionVirtualCalls.kt` now has `debugGetStackLevelInstance`, and
+    `ScriptLanguageExtension.kt`'s `_debugGetStackLevelInstance` carries
+    `@GodotVirtualMethod("_debug_get_stack_level_instance")`.
+  - Generated trampoline body for `instanceCreate` (confirms the write is exactly as designed):
+    ```kotlin
+    public val instanceCreate: GDExtensionClassCallVirtual =
+            staticCFunction { instancePtr, args, ret ->
+        val instance = instancePtr.getInstance<ScriptExtension>()
+        val arg0Ptr = requireNotNull(args?.`get`(0)).reinterpret<COpaquePointerVar>().pointed.`value`
+        val arg0 = GodotObject(requireNotNull(arg0Ptr) { "Argument 0 (Object) was null" })
+        val result = instance._instanceCreate(arg0)
+        ret?.reinterpret<COpaquePointerVar>()?.pointed?.`value` = result
+    }
+    ```
+- `:kotlin-native:api:generated:compileKotlinMacosArm64` — `BUILD SUCCESSFUL`, exit 0 (28s).
+- `:kotlin-native:api:generated:compileKotlinLinuxX64` — `BUILD SUCCESSFUL`, exit 0 (28s).
+- `:kotlin-native:api:generated:compileKotlinMingwX64` — `BUILD SUCCESSFUL`, exit 0 (26s).
+- Ran each task individually/scoped, never a single all-in-one `./gradlew assemble` (per #135's finding
+  that it OOMs on this machine from resource contention across concurrently-compiling targets).
+- `./gradlew spotlessApply` reformatted the touched file (no actual diff — it was already compliant)
+  and, as a known repo quirk, also pulled in an unrelated reformat of
+  `processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt`; reverted that file
+  with `git checkout --` to keep the diff scoped to this fix.
+
+### What is NOT verified
+
+Actual runtime behavior inside the Godot editor/engine is not verified by any of the above — only that
+the trampoline now exists in generated source and that the generated code compiles across all three
+Kotlin/Native targets. Whether Godot's `get_virtual_func` actually resolves and calls this trampoline
+correctly at runtime, and whether the raw `COpaquePointer` round-trips correctly through Godot's own
+`void*` handling on the C++ side, remains to be confirmed once #42's `KotlinScript._instanceCreate`
+override is exercised end-to-end in the editor.

--- a/docs/technical-design/virtual-dispatch.md
+++ b/docs/technical-design/virtual-dispatch.md
@@ -36,7 +36,7 @@ uniformly across all 106 classes — no per-class hand-listing, only per-*type-c
 | Direction | Supported | Deferred / unsupported |
 |---|---|---|
 | Argument | CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class/singleton object refs (nullable per `arg.isNullable`, matching `NativeMethodGenerator`), all opaque builtins (String, StringName, RID, Vector2/3, Dictionary, Variant, Transform3D, ...) wrapped by reference (no ownership) | `void*` (~19 methods, no verified pointer-indirection semantics for the read direction — risk is a native segfault, not a compile error, so skipped rather than guessed); native-structure-typed args |
-| Return | `void`, CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class (written via `.rawPtr`) | Heap-backed builtin returns (String/Array/Dictionary/Callable/Signal/NodePath/Packed*Array) — no `newCopyRaw`-equivalent placement-construct primitive exists yet for these; `VariantBinding.newCopyRaw` is the only one in the codebase |
+| Return | `void`, CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class (written via `.rawPtr`), `Variant` (via `VariantBinding.newCopyRaw`), every other heap-backed builtin with a copy constructor — String/Array/Dictionary/Packed\*Array/... (placement-constructed via `VariantBinding.getPtrConstructorRaw`, see #135), `void*` (written directly — `typeResolver` already resolves it to `COpaquePointer`, see #137) | Native-structure-typed returns |
 
 A method is only annotated/dispatchable when **every** argument AND the return type are supported.
 Partial support (e.g. skip one bad arg, keep the rest) was rejected — it would silently produce a


### PR DESCRIPTION
## The gap

`VirtualCallImplGen.isReturnSupported` (`codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt`) had no branch for `returnType == "void*"`. A virtual method only gets a `GDExtensionClassCallVirtual` trampoline when `isSupported()` returns true (every argument AND the return type supported). Without this branch, any virtual whose return type is `void*` got **no trampoline at all**: Godot's `get_virtual_func` returns `null` for it and silently falls back to its own C++ default (no-op) behavior — the Kotlin override compiles, but is never called.

Confirmed against `godot-version/v4_7_1/extension_api.json`: exactly 3 virtual methods return `void*`, all as the plain string `"void*"` (no `"const void*"` return ever appears, unlike argument types which use both forms):
- `ScriptExtension._instance_create`
- `ScriptExtension._placeholder_instance_create`
- `ScriptLanguageExtension._debug_get_stack_level_instance`

This is the last gap left over from #135 (heap-backed builtin returns), whose outcome section explicitly scoped `void*` out as "a separate, narrower case — a raw opaque pointer write, not a builtin placement-construct". Blocks #42 Fase 3: `ScriptExtension._instance_create` needs to actually be invokable so a Kotlin `KotlinScript._instanceCreate(forObject: GodotObject): COpaquePointer` override gets called by the engine.

Closes #137.

## The fix

- `isReturnSupported`: added `if (returnType == "void*") return true`.
- `buildReturnWrite`: added a `returnType == "void*"` branch, structurally identical to the existing `ctx.isEngineClass(returnType)` branch — `ret?.reinterpret<COpaquePointerVar>()?.pointed?.value = result` — but without the `.rawPtr` unwrap, since `typeResolver.resolve()` already maps `void*` directly to `COpaquePointer` (confirmed via `KotlinNativeTypeResolver.resolvePointer` + `KotlinNativeTypeResolverTest.kt`), so `result` is already the raw pointer value.
- No changes to `isArgSupported` (argument-side `void*` stays unsupported, unrelated/out of scope) or to `buildTrampoline`'s arg-read flow (`ScriptExtension._instance_create`'s single `Object`-typed arg was already supported via the existing engine-class arg branch).
- Updated the stale Return row in `docs/technical-design/virtual-dispatch.md` — it hadn't been updated by #135 either, so it's fixed to reflect both that fix's and this one's coverage.
- Design note: `docs/notes/issue-137-virtual-dispatch-void-return-plan.md` (scope written before implementing, Outcome section filled in after).

## Verification

Following #135's corrected methodology: real exit codes checked from log content (`grep`'d for `BUILD SUCCESSFUL`/`BUILD FAILED`), never through a pipe that could mask gradle's exit code. No single all-in-one `./gradlew assemble` (confirmed by #135 to OOM on this machine from resource contention) — scoped/targeted tasks only.

- `:codegen:api:kotlin-native:compileKotlin` — `BUILD SUCCESSFUL`, exit 0.
- `:codegen:api:kotlin-native:test` + `:codegen:api:common:test` — `BUILD SUCCESSFUL`, exit 0.
- `:kotlin-native:api:generated:generateGodotKotlinNativeApi` — regenerated; confirmed by reading the generated output directly (this worktree had no prior generated output to diff against):
  - `ScriptExtensionVirtualCalls.kt` now has `instanceCreate` and `placeholderInstanceCreate` trampoline properties.
  - `ScriptExtension.kt`'s `_instanceCreate`/`_placeholderInstanceCreate` now carry `@GodotVirtualMethod("_instance_create")` / `@GodotVirtualMethod("_placeholder_instance_create")`.
  - `ScriptLanguageExtensionVirtualCalls.kt` now has `debugGetStackLevelInstance`, and `ScriptLanguageExtension.kt`'s `_debugGetStackLevelInstance` carries the matching annotation.
  - Generated trampoline body, exactly as designed:
    ```kotlin
    public val instanceCreate: GDExtensionClassCallVirtual =
            staticCFunction { instancePtr, args, ret ->
        val instance = instancePtr.getInstance<ScriptExtension>()
        val arg0Ptr = requireNotNull(args?.`get`(0)).reinterpret<COpaquePointerVar>().pointed.`value`
        val arg0 = GodotObject(requireNotNull(arg0Ptr) { "Argument 0 (Object) was null" })
        val result = instance._instanceCreate(arg0)
        ret?.reinterpret<COpaquePointerVar>()?.pointed?.`value` = result
    }
    ```
- `:kotlin-native:api:generated:compileKotlinMacosArm64` — `BUILD SUCCESSFUL`, exit 0.
- `:kotlin-native:api:generated:compileKotlinLinuxX64` — `BUILD SUCCESSFUL`, exit 0.
- `:kotlin-native:api:generated:compileKotlinMingwX64` — `BUILD SUCCESSFUL`, exit 0.
- `./gradlew spotlessApply` reformatted nothing in the touched file (already compliant); as a known repo quirk it also pulled in an unrelated reformat of `processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt`, reverted with `git checkout --` to keep the diff scoped.

### What is NOT verified

Actual runtime behavior in the Godot editor/engine is **not** verified by any of the above — only that the trampoline now exists in generated source and compiles across all three Kotlin/Native targets. Whether Godot's `get_virtual_func` actually resolves and invokes this trampoline correctly at runtime, and whether the raw `COpaquePointer` round-trips correctly through Godot's own `void*` handling on the C++ side, remains to be confirmed once #42's `KotlinScript._instanceCreate` override is exercised end-to-end in the editor.

## Note for #42

Leaving this PR **open** (not merging) — `feat/kotlin-script-language` (#42) needs to rebase on top of this once ready. Repo owner to merge when satisfied.

## Resumen de Sourcery

Compatibilidad con retornos de métodos virtuales de `void*` para que los trampolines generados de Kotlin/Native expongan correctamente las devoluciones de llamada afectadas de las extensiones de Godot.

Correcciones de errores:
- Habilitar los trampolines de despacho virtual para métodos que devuelven `void*`, permitiendo invocar las sobrescrituras de Kotlin en lugar de recurrir silenciosamente a los valores predeterminados de Godot.

Mejoras:
- Documentar la compatibilidad con retornos de `void*` y actualizar la matriz de compatibilidad de tipos del despacho virtual.

Documentación:
- Añadir una nota de diseño que describa la brecha del despacho virtual de `void*`, su alcance, el resultado de la implementación y el estado de verificación.

Pruebas:
- Verificar la generación y compilación de código en los destinos de Kotlin/Native macOS ARM64, Linux x64 y MinGW x64, junto con las pruebas de generación de código.

<details>
<summary>Original summary in English</summary>

## Resumen de Sourcery

Admite valores de retorno `void*` en el despacho virtual de Kotlin/Native, de modo que las devoluciones de llamada afectadas de las extensiones de Godot puedan llegar a sus sobrescrituras en Kotlin.

Correcciones de errores:
- Habilitar las trampas de despacho virtual para métodos que devuelven `void*`, garantizando que se invoquen las sobrescrituras de Kotlin en lugar de recurrir silenciosamente a los valores predeterminados de Godot.

Mejoras:
- Admitir la escritura de valores de retorno `void*` sin procesar mediante trampas generadas de Kotlin/Native.
- Actualizar la matriz de compatibilidad de tipos del despacho virtual para incluir los valores de retorno `void*`.

Documentación:
- Añadir una nota de diseño que documente la brecha del despacho virtual de `void*`, su alcance, el resultado de la implementación y el estado de la verificación.

Pruebas:
- Verificar la generación y compilación de código en los destinos Kotlin/Native macOS ARM64, Linux x64 y MinGW x64, junto con las pruebas de generación de código.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support `void*` return values in Kotlin/Native virtual dispatch so affected Godot extension callbacks can reach their Kotlin overrides.

Bug Fixes:
- Enable virtual dispatch trampolines for methods returning `void*`, ensuring Kotlin overrides are invoked instead of silently falling back to Godot defaults.

Enhancements:
- Support writing raw `void*` return values through generated Kotlin/Native trampolines.
- Update the virtual-dispatch type-support matrix to include `void*` returns.

Documentation:
- Add a design note documenting the `void*` virtual-dispatch gap, scope, implementation outcome, and verification status.

Tests:
- Verify code generation and compilation across Kotlin/Native macOS ARM64, Linux x64, and MinGW x64 targets, along with codegen tests.

</details>

</details>