### PR TITLE
fix(codegen): always null-check engine-class virtual dispatch arguments

### DIFF
--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/generators/NativeEngineClassGenerator.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/generators/NativeEngineClassGenerator.kt
@@ -69,6 +69,10 @@ class NativeEngineClassGenerator(
                     method = method,
                     className = cls.name,
                     codeBody = body.buildMethodBody(method, cls.name),
+                    // Reverse dispatch (VirtualCallImplGen) always null-checks engine-class/singleton
+                    // args on the way in — the stub's own parameter type has to accept null too, or the
+                    // generated trampoline body won't type-check against it.
+                    forceNullableEngineArgs = method.isVirtual,
                 ) {
                     if (method.isVirtual) {
                         addModifiers(KModifier.OPEN)

--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/generators/NativeMethodGenerator.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/generators/NativeMethodGenerator.kt
@@ -45,6 +45,14 @@ class NativeMethodGenerator(
      *                       instead of the default `TODO()` stub. Callers supply this when an
      *                       implementation generator has
      *                       produced a real cinterop body.
+     * @param forceNullableEngineArgs When `true`, every engine-class/singleton-typed parameter is
+     *                       declared nullable regardless of [MethodArg.isNullable]. Used only for
+     *                       virtual method stubs: [MethodArg.isNullable] reflects a JSON default
+     *                       value, a forward-call-only concept — `extension_api.json` never sets one
+     *                       on a virtual method's arguments, yet the engine can and does hand back a
+     *                       genuine null pointer on dispatch (see `VirtualCallImplGen.appendArgRead`).
+     *                       Forward (non-virtual) call sites must keep passing `false` so their
+     *                       nullability stays exactly [MethodArg.isNullable]-derived, unchanged.
      * @param block          Extra customisation applied to the [FunSpec.Builder] after the
      *                       body is set (KDoc additions, annotations, etc.).
      */
@@ -54,6 +62,7 @@ class NativeMethodGenerator(
         className: String,
         codeBody: CodeBlock,
         vararg modifiers: KModifier,
+        forceNullableEngineArgs: Boolean = false,
         block: FunSpec.Builder.() -> Unit = {},
     ): FunSpec {
         withExceptionContext({ "Generating method $className.'${method.name}'" }) {
@@ -107,7 +116,9 @@ class NativeMethodGenerator(
                 require(!isVararg || safeIdentifier(arg.name) != "args") {
                     "Vararg method '$name' has a fixed arg named 'args' — rename it to avoid clash"
                 }
-                builder.addParameter(buildParameter(arg))
+                val forceNullable = forceNullableEngineArgs &&
+                    (context.isEngineClass(arg.type) || context.isSingleton(arg.type))
+                builder.addParameter(buildParameter(arg, forceNullable))
             }
 
             // Trailing vararg only after all fixed args
@@ -139,14 +150,18 @@ class NativeMethodGenerator(
      *
      * Default values from Godot JSON are emitted as `TODO()` —
      * the impl layer replaces them with actual expressions.
+     *
+     * @param forceNullable Forces a nullable type regardless of [MethodArg.isNullable]. See
+     *                       [buildMethod]'s `forceNullableEngineArgs` doc — only ever `true` for
+     *                       virtual method stubs.
      */
     context(context: Context)
-    fun buildParameter(arg: MethodArg): ParameterSpec {
+    fun buildParameter(arg: MethodArg, forceNullable: Boolean = false): ParameterSpec {
         withExceptionContext({
             "Generating parameter '${arg.name}': ${arg.type} (${arg.meta})} = ${arg.defaultValue ?: "--"}"
         }) {
             val rawType = typeResolver.resolve(arg)
-            val type = if (arg.isNullable) rawType.copy(nullable = true) else rawType
+            val type = if (arg.isNullable || forceNullable) rawType.copy(nullable = true) else rawType
             val kotlinName = safeIdentifier(arg.name)
             val paramBuilder = ParameterSpec.builder(kotlinName, type)
 

--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt
@@ -233,18 +233,15 @@ class VirtualCallImplGen(private val typeResolver: TypeResolver) {
                     cinteropPointed,
                     cinteropValue,
                 )
-                if (arg.isNullable) {
-                    addStatement("val %N = %N?.let·{·%T(it)·}", varName, ptrVar, kotlinType)
-                } else {
-                    addStatement(
-                        "val %N = %T(%M(%N) { %S })",
-                        varName,
-                        kotlinType,
-                        K_REQUIRE_NOT_NULL,
-                        ptrVar,
-                        "Argument $index (${arg.type}) was null",
-                    )
-                }
+                // Unlike a forward (Kotlin-calls-Godot) call, arg.isNullable's JSON-default-value heuristic
+                // says nothing about whether the *engine* can hand this pointer back as null on a virtual
+                // dispatch — it never does for this direction (extension_api.json has no default_value on
+                // virtual-method arguments at all). Godot genuinely does pass null here for some calls (e.g.
+                // ScriptLanguageExtension._complete_code's `owner` when the script isn't attached to a live
+                // scene object), so always take the null-safe path rather than requireNotNull-ing and
+                // crashing the whole process with an uncatchable Kotlin/Native exception across the
+                // staticCFunction boundary.
+                addStatement("val %N = %N?.let·{·%T(it)·}", varName, ptrVar, kotlinType)
             }
 
             ctx.isBuiltin(arg.type) -> addStatement("val %N = %T(%L)", varName, kotlinType, rawArg)

--- a/docs/notes/issue-141-virtual-dispatch-nullable-args-plan.md
+++ b/docs/notes/issue-141-virtual-dispatch-nullable-args-plan.md
@@ -1,0 +1,120 @@
+# Virtual dispatch: engine-class argument nullability (issue #141)
+
+## Problem
+
+Discovered real-editor-testing PR #134 (#42, Kotlin as a Godot script language): typing in a `.kt`
+file open in Godot's built-in script editor crashed the whole Godot process (`SIGABRT`) with
+
+```
+Uncaught Kotlin exception: kotlin.IllegalArgumentException: Argument 2 (Object) was null
+```
+
+inside `ScriptLanguageExtensionVirtualCalls.completeCode`'s generated trampoline. The exception can't
+cross the C callback boundary Kotlin/Native sets up for `staticCFunction`, so it aborts the process
+instead of propagating anywhere catchable.
+
+Root cause: `VirtualCallImplGen.appendArgRead`
+(`codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt`),
+in the `ctx.isEngineClass(arg.type) || ctx.isSingleton(arg.type)` branch, gated the null-safe
+`?.let { }` read vs. a `requireNotNull`-and-crash read on `arg.isNullable`
+(`codegen/api/common/src/main/kotlin/io/github/kingg22/godot/codegen/models/extensionapi/MethodArg.kt:14`
+— `type != "Variant" && defaultValue == "null"`, i.e. whether `extension_api.json` gives the argument an
+explicit `default_value: "null"`). That heuristic is correct for the *forward* direction (Kotlin calling
+into Godot, choosing to pass null to an optional parameter) but was being reused for the *reverse*
+direction here too — Godot calling into a Kotlin override — where it doesn't apply: confirmed via `jq`
+against `godot-version/v4_7_1/extension_api.json` that **zero** virtual-method arguments in the whole
+API ever carry a `default_value` key at all, so `arg.isNullable` was unconditionally `false` for every
+one of them. `ScriptLanguageExtension._complete_code`'s `owner: Object` argument has no default-value
+metadata, yet Godot genuinely passes null for it whenever the script being edited isn't attached to a
+live scene object (the ordinary case editing from the FileSystem dock).
+
+## Impact
+
+Not scoped to #42. Scanning `godot-version/v4_7_1/extension_api.json`: **142 of the engine's 1,437
+virtual methods across 41 classes** have at least one engine-class-typed argument, all sharing this
+crash-prone pattern — including common gameplay virtuals no kogot user has overridden yet:
+`Node._input`/`_shortcut_input`/`_unhandled_input`/`_unhandled_key_input(event: InputEvent)`,
+`Control._gui_input(event: InputEvent)`, `CollisionObject2D/3D._input_event(...)` (inherited by
+`Area2D/3D`, `PhysicsBody2D/3D`), `RigidBody2D/3D._integrate_forces(state)`.
+
+Also affects 10 overrides already shipped on PR #134's branch (`KotlinScriptLanguage.kt`,
+`KotlinScript.kt`, `KotlinResourceFormatSaver.kt`) — out of scope for this fix to touch directly (that
+branch rebases onto this one afterward and updates its own overrides).
+
+## Prior art in this lineage
+
+Same file, same discovery context (scoping #42/PR #134): #137/PR #138 (`void*` return support) and
+#139/PR #140 (`typedarray::*` return support) fixed analogous type-support gaps on the *return* side of
+this same reverse-dispatch trampoline. This issue is the *argument* side, and unlike those two isn't a
+missing-support gap (the method already compiles and dispatches either way) — it's a silent-crash
+correctness bug in an already-"supported" code path.
+
+## Scope
+
+1. `appendArgRead`'s `ctx.isEngineClass(arg.type) || ctx.isSingleton(arg.type)` branch: always take the
+   `?.let { }` null-safe read, unconditionally — stop consulting `arg.isNullable` for this branch
+   entirely.
+2. Consequence: the trampoline's local variable becomes `Type?` regardless of `arg.isNullable`, so the
+   `open fun` stub's own declared parameter type has to accept null too, or the generated call
+   `instance.method(arg0, ...)` won't type-check. `NativeMethodGenerator.buildMethod`/`buildParameter`
+   gets a `forceNullableEngineArgs`/`forceNullable` parameter (default `false`, so every other call site
+   — builtin constructors, static methods, utility functions, non-virtual instance methods — is
+   byte-for-byte unaffected), wired at `NativeEngineClassGenerator`'s standalone-instance-method call
+   site as `forceNullableEngineArgs = method.isVirtual`. Forward (non-virtual) method signatures stay
+   exactly `arg.isNullable`-derived, unchanged — `EngineMethodImplGen`/`Shared.kt` (the forward ptrcall
+   marshalling generators) are untouched, and don't need to be: `EngineMethodImplGen.buildMethodBody`
+   already short-circuits virtual methods to a `TODO()`/empty body before ever reaching the
+   argument-marshalling code that would care about the parameter's nullability.
+3. Leave the `ctx.isBuiltin(arg.type) -> "val %N = %T(%L)"` branch alone: builtin/value-typed virtual
+   arguments are passed by value via Godot's ptrcall convention — always a valid, possibly
+   default/empty, memory location, never a null pointer. Confirmed via the same `jq` query: no
+   builtin-typed virtual argument in `extension_api.json` is ever marked nullable either, consistent
+   with that ABI guarantee.
+4. Update the Argument row of `docs/technical-design/virtual-dispatch.md`'s type-support matrix, and add
+   a dedicated explanatory subsection (mirroring #137/#139's inline matrix notes).
+5. No test added: neither #135, #137, nor #139 (equally deep changes to this same generator) added a
+   unit test for `VirtualCallImplGen`/`NativeMethodGenerator` — there is no existing test file for
+   either, and building one from scratch (a `Context` with a populated `ResolvedApiModel.engineClasses`,
+   a real `TypeResolver`, an `ImplementationPackageRegistry`) is a disproportionate amount of net-new
+   test scaffolding for this fix alone. Matching precedent rather than introducing it unilaterally here.
+
+## Outcome
+
+Implemented as scoped:
+
+- `VirtualCallImplGen.appendArgRead`: the `ctx.isEngineClass(arg.type) || ctx.isSingleton(arg.type)`
+  branch's `if (arg.isNullable) { ?.let } else { requireNotNull }` became a single unconditional
+  `?.let { }` statement.
+- `NativeMethodGenerator.buildMethod`/`buildParameter`: added `forceNullableEngineArgs`/`forceNullable`
+  parameters (both default `false`).
+- `NativeEngineClassGenerator`: standalone instance method call site passes
+  `forceNullableEngineArgs = method.isVirtual`.
+- `docs/technical-design/virtual-dispatch.md`: Argument row + new explanatory subsection.
+
+### Verification (mirroring #135/#137/#139's methodology — real exit codes, no exit-code-masking pipes)
+
+- `:kotlin-native:api:generated:generateGodotKotlinNativeApi` — regenerated; confirmed by reading the
+  generated output directly:
+  - `ScriptLanguageExtension.kt`'s `_completeCode`: `owner` parameter is now `GodotObject?` (both the
+    `GodotString`-typed original and its all-Kotlin-`String` sibling overload).
+  - `ScriptLanguageExtensionVirtualCalls.kt`'s `completeCode` trampoline: `arg2 = arg2Ptr?.let {
+    GodotObject(it) }`, no `requireNotNull` on the engine-class argument.
+  - `Node.kt`'s `_input`: `event` parameter is now `InputEvent?`; `NodeVirtualCalls.kt`'s `input`
+    trampoline: `arg0 = arg0Ptr?.let { InputEvent(it) }`.
+- `./gradlew assemble` — see build log below (grepped directly for `BUILD SUCCESSFUL`/`BUILD FAILED`,
+  never piped through `tail`).
+- `./gradlew spotlessApply` — see below; any unrelated reformat of
+  `processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt` reverted with `git
+  checkout --`, per the known repo quirk #135/#137/#139 also hit.
+- Checked no other `main`-reachable code (outside PR #134's own branch, which is out of scope) overrides
+  a now-affected virtual with a non-nullable signature: `grep -rln "override fun _" --include="*.kt" .`
+  (excluding `build/`, `jvm-ffm/`) only turns up `mi-juego-prueba/kotlin_native_game/`'s
+  `Sprite.kt`/`TestOne.kt`/`SpriteBench.kt`, overriding `_ready()` (no args) and `_process(delta:
+  Double)` (primitive, not engine-class) — neither affected by this fix.
+
+### What is NOT verified
+
+Actual runtime behavior in the Godot editor/engine is not verified by any of the above — only that the
+generated code compiles and matches the intended null-safe shape. Whether this actually stops the
+original `_complete_code` crash end-to-end in the editor remains to be confirmed once #42/PR #134
+rebases onto this fix and re-exercises the script editor.

--- a/docs/technical-design/virtual-dispatch.md
+++ b/docs/technical-design/virtual-dispatch.md
@@ -35,12 +35,37 @@ uniformly across all 106 classes — no per-class hand-listing, only per-*type-c
 
 | Direction | Supported | Deferred / unsupported |
 |---|---|---|
-| Argument | CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class/singleton object refs (nullable per `arg.isNullable`, matching `NativeMethodGenerator`), all opaque builtins (String, StringName, RID, Vector2/3, Dictionary, Variant, Transform3D, ...) wrapped by reference (no ownership) | `void*` (~19 methods, no verified pointer-indirection semantics for the read direction — risk is a native segfault, not a compile error, so skipped rather than guessed); native-structure-typed args |
+| Argument | CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class/singleton object refs (**always** nullable — see below, not gated by `arg.isNullable`), all opaque builtins (String, StringName, RID, Vector2/3, Dictionary, Variant, Transform3D, ...) wrapped by reference (no ownership, never null — passed by value via ptrcall) | `void*` (~19 methods, no verified pointer-indirection semantics for the read direction — risk is a native segfault, not a compile error, so skipped rather than guessed); native-structure-typed args |
 | Return | `void`, CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class (written via `.rawPtr`), `Variant` (via `VariantBinding.newCopyRaw`), every other heap-backed builtin with a copy constructor — String/Array/Dictionary/Packed\*Array/... (placement-constructed via `VariantBinding.getPtrConstructorRaw`, see #135), `void*` (written directly — `typeResolver` already resolves it to `COpaquePointer`, see #137), `typedarray::*` (shares the plain `Array` copy-constructor fptr — a typed array is still exactly an `Array` at the ABI level, see #139) | Native-structure-typed returns |
 
 A method is only annotated/dispatchable when **every** argument AND the return type are supported.
 Partial support (e.g. skip one bad arg, keep the rest) was rejected — it would silently produce a
 wrong-arity override.
+
+### Engine-class/singleton arguments are always nullable (see issue #141)
+
+`VirtualCallImplGen.appendArgRead` used to gate the null-check on `arg.isNullable` — the same flag
+`NativeMethodGenerator` uses for *forward* (Kotlin-calls-Godot) optional parameters, derived from
+whether `extension_api.json` gives the argument an explicit `default_value: "null"`. That heuristic
+doesn't apply here: `extension_api.json` never sets `default_value` on a virtual method's arguments at
+all (confirmed empirically against v4.7.1 — zero virtual-method arguments have the key), so
+`arg.isNullable` was always `false` for every one of them, and the reverse-dispatch trampoline always
+took the `requireNotNull` path. Godot's C++ side genuinely does pass a null `Object*` on some virtual
+calls regardless — e.g. `ScriptLanguageExtension._complete_code`'s `owner` argument whenever the script
+being edited isn't attached to a live scene object (the ordinary case editing from the FileSystem
+dock). `requireNotNull` throwing a Kotlin exception here is fatal: the exception can't cross the C
+callback boundary `staticCFunction` sets up, so it aborts the whole Godot process instead of failing
+gracefully.
+
+The fix: `appendArgRead` now *always* takes the null-safe `?.let { }` path for engine-class/singleton
+arguments, unconditionally — `arg.isNullable` is no longer consulted for this branch. Since the
+trampoline's local variable is now `Type?`, the `open fun` stub's own parameter also has to accept
+null (`NativeMethodGenerator.buildMethod`'s `forceNullableEngineArgs`, threaded through only for
+`method.isVirtual`) — this is a source-breaking signature change for every existing override of an
+affected virtual (`Type` -> `Type?`). Builtin-typed (opaque, by-reference) virtual arguments are
+unaffected: they're passed by value via Godot's ptrcall convention, which always hands over a valid
+(possibly default/empty) memory location, never a null pointer — confirmed no builtin-typed virtual
+argument in `extension_api.json` is ever marked nullable either, consistent with that ABI guarantee.
 
 Explicitly out of scope: brand-new user-declared virtuals with no engine counterpart (not coherent —
 Godot only ever queries names from its own virtual method table); `getVirtual`'s `hash` parameter


### PR DESCRIPTION
## The gap

`VirtualCallImplGen.appendArgRead` (`codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt`) gated whether a reverse-dispatch (Godot-calls-into-Kotlin) virtual method's engine-class/singleton-typed argument got read via a null-safe `?.let { }` or a `requireNotNull`, on `arg.isNullable`. That flag (`MethodArg.isNullable`, `codegen/api/common/.../MethodArg.kt:14` — `type != "Variant" && defaultValue == "null"`) reflects whether `extension_api.json` gives an argument an explicit `default_value: "null"`. Correct heuristic for the *forward* direction (a Kotlin caller choosing to pass null to an optional parameter) — reused here for the *reverse* direction too, where it doesn't apply: confirmed via `jq` against `godot-version/v4_7_1/extension_api.json` that **zero** virtual-method arguments in the whole API ever carry a `default_value` key, so `arg.isNullable` was unconditionally `false` for all of them, and the trampoline always took the `requireNotNull` path.

Godot genuinely does hand back null on some of these calls. Real-editor-testing PR #134 (#42) hit a live crash: typing in a `.kt` file open in Godot's built-in script editor triggered

```
Uncaught Kotlin exception: kotlin.IllegalArgumentException: Argument 2 (Object) was null
```

inside `ScriptLanguageExtensionVirtualCalls.completeCode`'s trampoline, **aborting the whole Godot process** — the exception can't cross the C callback boundary Kotlin/Native sets up for `staticCFunction`. `ScriptLanguageExtension._complete_code`'s `owner: Object` argument has no default-value metadata, yet Godot passes null for it whenever the script being edited isn't attached to a live scene object — the ordinary case editing from the FileSystem dock.

**Not scoped to #42.** Scanning `godot-version/v4_7_1/extension_api.json`: 142 of the engine's 1,437 virtual methods across 41 classes have at least one engine-class-typed argument sharing this exact crash-prone pattern, including gameplay virtuals no kogot user has overridden yet but certainly will: `Node._input`/`_shortcutInput`/`_unhandledInput`/`_unhandledKeyInput`, `Control._guiInput`, `CollisionObject2D/3D._inputEvent` (inherited by `Area2D/3D`, `PhysicsBody2D/3D`), `RigidBody2D/3D._integrateForces`. Also affects 10 overrides already shipped on PR #134's branch (`KotlinScriptLanguage.kt`/`KotlinScript.kt`/`KotlinResourceFormatSaver.kt`) — left for that branch to update itself once it rebases onto this.

Closes #141.

## The fix

- `appendArgRead`'s `ctx.isEngineClass(arg.type) || ctx.isSingleton(arg.type)` branch now always takes the null-safe `?.let { }` read, unconditionally — `arg.isNullable` is no longer consulted for this branch at all.
- Consequence: the trampoline's local variable becomes `Type?` regardless of `arg.isNullable`, so the `open fun` stub's own declared parameter has to accept null too, or the generated `instance.method(arg0, ...)` call won't type-check. `NativeMethodGenerator.buildMethod`/`buildParameter` gained a `forceNullableEngineArgs`/`forceNullable` parameter (default `false`, so every other call site — builtin constructors, static methods, utility functions, non-virtual instance methods — is byte-for-byte unaffected), wired at `NativeEngineClassGenerator`'s standalone-instance-method call site as `forceNullableEngineArgs = method.isVirtual`. Forward (non-virtual) method signatures stay exactly `arg.isNullable`-derived, unchanged — `EngineMethodImplGen`/`Shared.kt` (the forward ptrcall marshalling generators) needed no changes at all: `EngineMethodImplGen.buildMethodBody` already short-circuits virtual methods to a `TODO()`/empty body before ever reaching the argument-marshalling code, so the now-wider parameter type never gets dereferenced there.
- Left `ctx.isBuiltin(arg.type)` alone: builtin/value-typed virtual arguments are passed by value via Godot's ptrcall convention — always a valid (possibly default/empty) memory location, never a null pointer. Confirmed via the same `jq` query that no builtin-typed virtual argument in `extension_api.json` is ever marked nullable either, consistent with that ABI guarantee.
- Updated the Argument row + added an explanatory subsection to `docs/technical-design/virtual-dispatch.md`.
- Design note: `docs/notes/issue-141-virtual-dispatch-nullable-args-plan.md` (scope + outcome), following #135/#137/#139's convention.
- No test added: neither #135, #137, nor #139 (equally deep changes to this same generator) added a unit test for `VirtualCallImplGen`/`NativeMethodGenerator` — there is no existing test file for either, and building the scaffolding from scratch (a `Context` with a populated `ResolvedApiModel.engineClasses`, a real `TypeResolver`, an `ImplementationPackageRegistry`) is disproportionate to this fix alone. Matching precedent rather than introducing it unilaterally here.

## Verification

Following #135/#137/#139's methodology: real exit codes checked from log content (`grep`'d directly for `BUILD SUCCESSFUL`/`BUILD FAILED`, never through a pipe that could mask gradle's exit code).

- `:kotlin-native:api:generated:generateGodotKotlinNativeApi` — regenerated; confirmed by reading the generated output directly:
  - `ScriptLanguageExtension.kt`'s `_completeCode`: `owner` is now `GodotObject?` (both the `GodotString`-typed original and its all-Kotlin-`String` sibling overload).
  - `ScriptLanguageExtensionVirtualCalls.kt`'s `completeCode` trampoline: `val arg2 = arg2Ptr?.let { GodotObject(it) }`, no `requireNotNull` on the engine-class argument.
  - `Node.kt`'s `_input`: `event` is now `InputEvent?`; `NodeVirtualCalls.kt`'s `input` trampoline reads it the same null-safe way.
- `./gradlew assemble` — `BUILD SUCCESSFUL`. First full run hit `OutOfMemoryError: Java heap space` in 3 unrelated native-linking tasks (`kotlin-native:sample:linkDebugSharedMacosArm64`, `mi-juego-prueba:kotlin_native_game:export:linkDebugSharedLinuxX64`/`MacosArm64`) under heavy concurrent system load — a known pre-existing resource-contention issue on this machine (see the `org.gradle.parallel` revert in git history), not a compile error: every task touching this fix's code (`codegen:api:kotlin-native:compileKotlin`, `kotlin-native:api:generated:assemble` across all 3 native targets, `kotlin-native:binding:assemble`) succeeded cleanly in that same run. A retry with `--max-workers=2` reused the cached results and completed in under 2 minutes with `BUILD SUCCESSFUL`, no failed tasks.
- `./gradlew spotlessApply` — `BUILD SUCCESSFUL`; as a known repo quirk it also pulled in an unrelated reformat of `processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt`, reverted with `git checkout --` to keep the diff scoped to this fix.
- Checked no other `main`-reachable code overrides a now-affected virtual with a non-nullable signature: `grep -rln "override fun _" --include="*.kt" .` (excluding `build/`, `jvm-ffm/`, and PR #134's own branch, out of scope) only turns up `mi-juego-prueba/kotlin_native_game/`'s `Sprite.kt`/`TestOne.kt`/`SpriteBench.kt`, overriding `_ready()` (no args) and `_process(delta: Double)` (primitive) — neither affected.

### What is NOT verified

Actual runtime behavior in the Godot editor/engine is not verified by any of the above — only that the generated code compiles and matches the intended null-safe shape. Whether this actually stops the original `_complete_code` crash end-to-end in the editor remains to be confirmed once #42/PR #134 rebases onto this fix and re-exercises the script editor.

## Note for #42

Leaving this PR to be merged by the repo owner, same as PR #138/#140 — `feat/kotlin-script-language` (#42/PR #134) needs to rebase onto this afterward and update its own 10 affected overrides (`_openInExternalEditor`, `_completeCode`, `_lookupCode`, `_reloadToolScript`, `_instanceCreate`, `_inheritsScript`, `_placeholderInstanceCreate`, `_getRecognizedExtensions`/`_recognize`/`_save`) to the new nullable signatures.

## Resumen de Sourcery

Hacer que los argumentos de clases del motor y singletons en el despacho virtual sean siempre compatibles con valores nulos para evitar que las callbacks de Godot interrumpan el proceso.

Correcciones de errores:
- Evitar fallos durante las llamadas virtuales de despacho inverso cuando Godot proporciona argumentos nulos de objetos del motor o singletons.
- Generar parámetros que admitan valores nulos para los stubs de métodos virtuales afectados, de modo que el despacho seguro frente a valores nulos siga siendo correcto en cuanto a tipos.

Mejoras:
- Mantener el comportamiento existente de nulabilidad para las llamadas de despacho directo y dejar sin cambios los argumentos integrados con tipos de valor.

Documentación:
- Documentar el comportamiento de nulabilidad y su justificación para los argumentos de clases del motor y singletons en el despacho virtual.
- Añadir una nota de diseño que describa el problema, el alcance, el resultado y la verificación.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make engine-class and singleton arguments in virtual dispatch consistently null-safe to prevent Godot callbacks from aborting the process.

Bug Fixes:
- Prevent crashes during reverse-dispatch virtual calls when Godot supplies null engine-object or singleton arguments.
- Generate nullable parameters for affected virtual method stubs so null-safe dispatch remains type-correct.

Enhancements:
- Preserve existing nullability behavior for forward calls and leave builtin value-typed arguments unchanged.

Documentation:
- Document the nullability behavior and rationale for engine-class and singleton virtual-dispatch arguments.
- Add a design note describing the issue, scope, outcome, and verification.

</details>