### PR TITLE
fix(codegen): always null-check engine-class virtual dispatch returns

### DIFF
--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/generators/NativeEngineClassGenerator.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/generators/NativeEngineClassGenerator.kt
@@ -73,6 +73,12 @@ class NativeEngineClassGenerator(
                     // args on the way in — the stub's own parameter type has to accept null too, or the
                     // generated trampoline body won't type-check against it.
                     forceNullableEngineArgs = method.isVirtual,
+                    // Mirror of the above for the return side: COpaquePointer (behind rawPtr) can't
+                    // itself represent a null address, so an override's only way to hand back "no
+                    // value" for an engine-class/singleton return is a null reference. The trampoline's
+                    // return write (VirtualCallImplGen.buildReturnWrite) already null-checks `result`
+                    // before writing .rawPtr, so declaring the return type nullable is safe and required.
+                    forceNullableEngineReturn = method.isVirtual,
                 ) {
                     if (method.isVirtual) {
                         addModifiers(KModifier.OPEN)

--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/generators/NativeMethodGenerator.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/generators/NativeMethodGenerator.kt
@@ -53,6 +53,16 @@ class NativeMethodGenerator(
      *                       genuine null pointer on dispatch (see `VirtualCallImplGen.appendArgRead`).
      *                       Forward (non-virtual) call sites must keep passing `false` so their
      *                       nullability stays exactly [MethodArg.isNullable]-derived, unchanged.
+     * @param forceNullableEngineReturn When `true` and the method's return type resolves to an
+     *                       engine class or singleton, the return type is declared nullable
+     *                       (`.copy(nullable = true)`). Used only for virtual method stubs: a
+     *                       `COpaquePointer` (the type behind `GodotObject.rawPtr`) cannot itself
+     *                       represent a null address — the only way a Kotlin override can hand back
+     *                       "no value" for one of these virtuals is by returning a `null` reference —
+     *                       yet the generated return type was always declared non-nullable, making
+     *                       that architecturally impossible (see `VirtualCallImplGen.buildReturnWrite`).
+     *                       Forward (non-virtual) call sites must keep passing `false` so their return
+     *                       type stays exactly as resolved, unchanged.
      * @param block          Extra customisation applied to the [FunSpec.Builder] after the
      *                       body is set (KDoc additions, annotations, etc.).
      */
@@ -63,10 +73,11 @@ class NativeMethodGenerator(
         codeBody: CodeBlock,
         vararg modifiers: KModifier,
         forceNullableEngineArgs: Boolean = false,
+        forceNullableEngineReturn: Boolean = false,
         block: FunSpec.Builder.() -> Unit = {},
     ): FunSpec {
         withExceptionContext({ "Generating method $className.'${method.name}'" }) {
-            val (returnTypeSpec, originalType, originalMeta) = when (method) {
+            val (rawReturnTypeSpec, originalType, originalMeta) = when (method) {
                 is BuiltinClass.BuiltinMethod -> Triple(
                     method.returnType?.let { typeResolver.resolve(it) } ?: UNIT,
                     method.returnType,
@@ -84,6 +95,15 @@ class NativeMethodGenerator(
                     method.returnType,
                     null,
                 )
+            }
+
+            val returnTypeSpec = if (forceNullableEngineReturn &&
+                originalType != null &&
+                (context.isEngineClass(originalType) || context.isSingleton(originalType))
+            ) {
+                rawReturnTypeSpec.copy(nullable = true)
+            } else {
+                rawReturnTypeSpec
             }
 
             val name = method.name

--- a/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt
+++ b/codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt
@@ -286,8 +286,15 @@ class VirtualCallImplGen(private val typeResolver: TypeResolver) {
                 cinteropValue,
             )
 
+            // NativeEngineClassGenerator's virtual-stub call site passes forceNullableEngineReturn =
+            // method.isVirtual, so `result` is Type? here for every engine-class-returning virtual —
+            // COpaquePointer (behind rawPtr) can't itself represent a null address, so a null `result`
+            // has to become a null-safe read (`result?.rawPtr` evaluates to null), not a direct property
+            // access, or a genuinely-null override return would NPE inside the trampoline instead of
+            // correctly reporting "no value" back to Godot. Mirrors appendArgRead's `?.let { }` null
+            // safety on the read side of this same trampoline.
             ctx.isEngineClass(returnType) -> addStatement(
-                "ret?.%M<%T>()?.%M?.%M = result.rawPtr",
+                "ret?.%M<%T>()?.%M?.%M = result?.rawPtr",
                 cinteropReinterpret,
                 C_OPAQUE_POINTER_VAR,
                 cinteropPointed,

--- a/docs/notes/issue-143-virtual-dispatch-nullable-returns-plan.md
+++ b/docs/notes/issue-143-virtual-dispatch-nullable-returns-plan.md
@@ -1,0 +1,129 @@
+# Virtual dispatch: engine-class return nullability (issue #143)
+
+## Problem
+
+`VirtualCallImplGen.buildReturnWrite`
+(`codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt`)'s
+`ctx.isEngineClass(returnType)` branch unconditionally writes `result.rawPtr` for any virtual method
+whose return type is an engine class. Meanwhile the generated Kotlin stub for that same virtual
+(`NativeMethodGenerator.buildMethod`'s `.returns(returnTypeSpec)`) always declares the return type
+non-nullable — there was no return-side equivalent of `buildParameter`'s existing `forceNullable`
+parameter, which `NativeEngineClassGenerator.kt` already passed for virtual-method *arguments*
+(`forceNullableEngineArgs = method.isVirtual`, see issue #141/PR #142).
+
+`COpaquePointer` (the type behind `GodotObject.rawPtr`) cannot itself represent a null address —
+kotlinx.cinterop's own `CPointer<T>` is non-null by construction; a null address can only ever surface
+as a Kotlin `null` reference. With the return type forced non-nullable, no Kotlin override of one of
+these virtuals could ever hand back "no value" to Godot — every override was forced to always return
+*some* real object.
+
+## Impact
+
+Confirmed via real-editor testing on PR #134 (issue #42, Kotlin as a Godot script language).
+`ScriptExtension._get_base_script` is a required virtual (`is_required: true` in `extension_api.json`)
+whose C++ caller, `EditorData::get_script_icon` (`editor/editor_data.cpp:1213-1239`), walks the
+base-script chain with **no cycle detection or iteration limit**:
+
+```cpp
+Ref<Script> base_scr = ResourceLoader::load(p_script_path, "Script");
+while (base_scr.is_valid()) {
+    ...
+    icon_path = base_scr->get_class_icon_path();   // crash site
+    ...
+    base_scr = base_scr->get_base_script();          // line 1239, no guard
+}
+```
+
+`Ref<T>::is_valid()` is a plain null-pointer check — it does **not** call the script's own `_is_valid()`
+virtual. A Kotlin `@Godot` class always inherits its native ClassDB parent, never another `Script`
+resource, so there's genuinely no base script to report — but `KotlinScript._getBaseScript()` was forced
+to return a real, non-null object every time (a shared sentinel), including when called *on that
+sentinel itself*. The loop never terminates. Confirmed via a self-built Godot 4.7.1 dev binary under
+lldb: the object handed back each iteration is a legitimately valid, non-corrupted `ScriptExtension*`
+(ruling out memory corruption) — the crash (SIGSEGV inside Godot's own `EditorData::get_script_icon`) is
+a downstream consequence of the unbounded loop, not a direct null-deref.
+
+Scanning `godot-version/v4_7_1/extension_api.json`: **43 virtual methods across 30 classes** return an
+engine-class type, all sharing this same architectural gap — no override of any of them can ever express
+"no value." Beyond `ScriptExtension._get_base_script`, several are documented in Godot's own C++ headers
+as legitimately nullable ("return nullptr if unimplemented" or similar): `AudioEffect._instantiate`,
+`Control._make_custom_tooltip`, `EditorPlugin._get_plugin_icon`, `Mesh._surface_get_material`,
+`PhysicsServer2D/3DExtension._space_get_direct_state`/`_body_get_direct_state`, `Texture2D._get_image`,
+`VideoStreamPlayback._get_texture`, `ScriptLanguageExtension._create_script` (`is_required: false`).
+
+## Prior art in this lineage
+
+Same file, same discovery lineage (scoping PR #134/#42): #137/PR #138 (`void*` return support),
+#139/PR #140 (`typedarray::*` return support), #141/PR #142 (argument nullability — the direct sibling
+of this issue, on the opposite side of the same trampoline). This issue mirrors #141/#142's approach but
+for the return side instead of the argument side.
+
+## Scope
+
+1. `NativeMethodGenerator.buildMethod` gets a `forceNullableEngineReturn: Boolean = false` parameter
+   (default `false`, so every other call site — builtin constructors, static methods, utility functions,
+   non-virtual instance methods — is byte-for-byte unaffected) that makes `returnTypeSpec` nullable
+   (`.copy(nullable = true)`) when the return type resolves to an engine class or singleton and the flag
+   is set.
+2. `NativeEngineClassGenerator.kt`'s standalone-instance-method `buildMethod(...)` call site (the same
+   one that already passes `forceNullableEngineArgs = method.isVirtual`) passes
+   `forceNullableEngineReturn = method.isVirtual` alongside it. The static-methods call site is left
+   untouched — static methods are never virtual, matching how it never received
+   `forceNullableEngineArgs` either.
+3. `VirtualCallImplGen.buildReturnWrite`'s `ctx.isEngineClass(returnType)` branch gets a null check on
+   `result` before writing `.rawPtr`: `result?.rawPtr` instead of `result.rawPtr`, writing a null pointer
+   into the `COpaquePointerVar`'s (nullable) `.value` when `result` is null — mirroring how
+   `appendArgRead`'s sibling engine-class branch already does `val %N = %N?.let { %T(it) }` for the read
+   side.
+4. Applied unconditionally to all 43 affected virtuals, matching how #141/#142 applied unconditionally
+   to arguments regardless of any JSON metadata — not special-cased to `_get_base_script`, and not
+   conditioned on `is_required` (`extension_api.json`'s `is_required: true` on `_get_base_script` means
+   the virtual itself must be implemented, not that its return value can't be null).
+5. Update the Return row of `docs/technical-design/virtual-dispatch.md`'s type-support matrix, and add a
+   dedicated explanatory subsection (mirroring #141's Argument-side subsection).
+6. No test added: matching precedent from #135/#137/#139/#141, none of which added a unit test for this
+   generator — there is no existing test file for `VirtualCallImplGen`/`NativeMethodGenerator`, and
+   building the scaffolding from scratch (a `Context` with a populated `ResolvedApiModel.engineClasses`,
+   a real `TypeResolver`, an `ImplementationPackageRegistry`) is disproportionate to this fix alone.
+
+## Outcome
+
+Implemented as scoped:
+
+- `NativeMethodGenerator.buildMethod`: added `forceNullableEngineReturn` parameter (default `false`).
+  The return type is computed from the original `Triple` as before, then conditionally widened to
+  nullable via `.copy(nullable = true)` when `forceNullableEngineReturn` is set and the original JSON
+  return type resolves to an engine class or singleton (`originalType != null &&
+  (context.isEngineClass(originalType) || context.isSingleton(originalType))`).
+- `NativeEngineClassGenerator`: standalone instance method call site passes
+  `forceNullableEngineReturn = method.isVirtual` alongside the existing `forceNullableEngineArgs`.
+- `VirtualCallImplGen.buildReturnWrite`: the `ctx.isEngineClass(returnType)` branch's write changed from
+  `result.rawPtr` to `result?.rawPtr` — a one-token null-safe-call change, since `result`'s static type
+  is now `Type?` for every affected virtual once the two generator changes above are wired.
+- `docs/technical-design/virtual-dispatch.md`: Return row + new explanatory subsection.
+
+### Verification (mirroring #135/#137/#139/#141's methodology — real exit codes, no exit-code-masking pipes)
+
+- `:kotlin-native:api:generated:generateGodotKotlinNativeApi` — regenerated; confirmed by reading the
+  generated output directly:
+  - `ScriptExtension.kt`'s `_getBaseScript()`: return type is now `Script?`, and the `TODO()` stub body
+    is unchanged (still a stub — only the declared type changed).
+  - `ScriptExtensionVirtualCalls.kt`'s `getBaseScript` trampoline: writes
+    `ret?.reinterpret<COpaquePointerVar>()?.pointed?.value = result?.rawPtr`, null-safe on the
+    engine-class return.
+  - Spot-checked `Texture2D._get_image` / `Mesh._surface_get_material` and other affected virtuals from
+    the issue's list — same nullable-return + null-safe-write shape.
+- `./gradlew assemble` — see PR body for the actual log result.
+- `./gradlew spotlessApply` — any unrelated reformat of
+  `processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt` reverted with `git
+  checkout --`, per the known repo quirk #135/#137/#139/#141 also hit.
+- Checked no other `main`-reachable code (outside PR #134's own branch, which is out of scope) overrides
+  a now-affected virtual with a non-nullable return signature: `grep -rln "override fun _" --include="*.kt" .`
+  (excluding `build/` and any other worktree paths) — see PR body for the actual result.
+
+### What is NOT verified
+
+Actual runtime behavior in the Godot editor/engine is not verified by any of the above — only that the
+generated code compiles and matches the intended nullable-return shape. Whether this actually stops the
+`ScriptExtension._get_base_script` infinite loop end-to-end in the editor remains to be confirmed once
+#42/PR #134 rebases onto this fix and re-exercises the script editor with a real `KotlinScript`.

--- a/docs/technical-design/virtual-dispatch.md
+++ b/docs/technical-design/virtual-dispatch.md
@@ -36,7 +36,7 @@ uniformly across all 106 classes — no per-class hand-listing, only per-*type-c
 | Direction | Supported | Deferred / unsupported |
 |---|---|---|
 | Argument | CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class/singleton object refs (**always** nullable — see below, not gated by `arg.isNullable`), all opaque builtins (String, StringName, RID, Vector2/3, Dictionary, Variant, Transform3D, ...) wrapped by reference (no ownership, never null — passed by value via ptrcall) | `void*` (~19 methods, no verified pointer-indirection semantics for the read direction — risk is a native segfault, not a compile error, so skipped rather than guessed); native-structure-typed args |
-| Return | `void`, CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class (written via `.rawPtr`), `Variant` (via `VariantBinding.newCopyRaw`), every other heap-backed builtin with a copy constructor — String/Array/Dictionary/Packed\*Array/... (placement-constructed via `VariantBinding.getPtrConstructorRaw`, see #135), `void*` (written directly — `typeResolver` already resolves it to `COpaquePointer`, see #137), `typedarray::*` (shares the plain `Array` copy-constructor fptr — a typed array is still exactly an `Array` at the ABI level, see #139) | Native-structure-typed returns |
+| Return | `void`, CVar primitives, `bool`, `enum::`/`bitfield::`, engine-class (**always** nullable — see below, not gated by any JSON metadata — written via null-safe `?.rawPtr`), `Variant` (via `VariantBinding.newCopyRaw`), every other heap-backed builtin with a copy constructor — String/Array/Dictionary/Packed\*Array/... (placement-constructed via `VariantBinding.getPtrConstructorRaw`, see #135), `void*` (written directly — `typeResolver` already resolves it to `COpaquePointer`, see #137), `typedarray::*` (shares the plain `Array` copy-constructor fptr — a typed array is still exactly an `Array` at the ABI level, see #139) | Native-structure-typed returns |
 
 A method is only annotated/dispatchable when **every** argument AND the return type are supported.
 Partial support (e.g. skip one bad arg, keep the rest) was rejected — it would silently produce a
@@ -66,6 +66,37 @@ affected virtual (`Type` -> `Type?`). Builtin-typed (opaque, by-reference) virtu
 unaffected: they're passed by value via Godot's ptrcall convention, which always hands over a valid
 (possibly default/empty) memory location, never a null pointer — confirmed no builtin-typed virtual
 argument in `extension_api.json` is ever marked nullable either, consistent with that ABI guarantee.
+
+### Engine-class/singleton returns are always nullable (see issue #143)
+
+`VirtualCallImplGen.buildReturnWrite`'s `ctx.isEngineClass(returnType)` branch used to write
+`result.rawPtr` unconditionally. `COpaquePointer` (the type behind `GodotObject.rawPtr`) cannot itself
+represent a null address — kotlinx.cinterop's `CPointer<T>` is non-null by construction, so a null
+address can only ever surface as a Kotlin `null` reference — yet the generated stub's return type
+(`NativeMethodGenerator.buildMethod`'s `.returns(returnTypeSpec)`) was always declared non-nullable, with
+no return-side equivalent of the argument-side `forceNullable`. No override of one of these virtuals
+could ever hand back "no value" to Godot.
+
+Confirmed as a real, crash-causing gap by real-editor-testing PR #134 (#42): `ScriptExtension
+._get_base_script` is forced to always return a real object, and Godot's own `EditorData
+::get_script_icon` (`editor/editor_data.cpp`) walks the base-script chain via a bare `Ref<T>::is_valid()`
+null check with zero cycle detection — a self-returning sentinel never terminates the loop, eventually
+crashing the editor. Confirmed via lldb that the returned object itself is not corrupted: this is purely
+an inability-to-express-null bug, not a memory-safety one. Scanning `extension_api.json` v4.7.1: 43
+virtual methods across 30 classes return an engine-class type, all sharing this same gap — several
+documented in Godot's own C++ headers as legitimately nullable (`AudioEffect._instantiate`,
+`Mesh._surface_get_material`, `Texture2D._get_image`, ...). The fix applies uniformly to all 43,
+regardless of any JSON metadata — `extension_api.json`'s `is_required: true` on a virtual (e.g.
+`_get_base_script`) means the virtual itself must be implemented, not that its return value can't be
+null.
+
+The fix: `NativeMethodGenerator.buildMethod` gained a `forceNullableEngineReturn` parameter (default
+`false`, threaded through only for `method.isVirtual` at `NativeEngineClassGenerator`'s standalone
+instance-method call site, mirroring `forceNullableEngineArgs`) that declares the return type nullable
+when it resolves to an engine class or singleton. `VirtualCallImplGen.buildReturnWrite`'s engine-class
+branch now writes `result?.rawPtr` instead of `result.rawPtr` — a null-safe read matching
+`appendArgRead`'s `?.let { }` on the argument side of this same trampoline. This is a source-breaking
+signature change for every existing override of one of the 43 affected virtuals (`Type` -> `Type?`).
 
 Explicitly out of scope: brand-new user-declared virtuals with no engine counterpart (not coherent —
 Godot only ever queries names from its own virtual method table); `getVirtual`'s `hash` parameter


### PR DESCRIPTION
## The gap

`VirtualCallImplGen.buildReturnWrite` (`codegen/api/kotlin-native/src/main/kotlin/io/github/kingg22/godot/codegen/extensionapi/impl/knative/impl/VirtualCallImplGen.kt`), in the `ctx.isEngineClass(returnType)` branch, unconditionally wrote `result.rawPtr` for any virtual method whose return type is an engine class. Meanwhile the generated Kotlin stub for that same virtual (`NativeMethodGenerator.buildMethod`'s `.returns(returnTypeSpec)`) always declared the return type non-nullable — there was no return-side equivalent of `buildParameter`'s existing `forceNullable`, which `NativeEngineClassGenerator.kt` already passed for virtual-method *arguments* (`forceNullableEngineArgs = method.isVirtual`, see #141/PR #142).

`COpaquePointer` (the type behind `GodotObject.rawPtr`) cannot itself represent a null address — kotlinx.cinterop's own `CPointer<T>` is non-null by construction; a null address can only ever surface as a Kotlin `null` reference. With the return type forced non-nullable, no override of one of these virtuals could ever hand back "no value" to Godot.

Confirmed as a real crash by real-editor testing on PR #134 (#42): `ScriptExtension._get_base_script` is a required virtual whose C++ caller, `EditorData::get_script_icon` (`editor/editor_data.cpp:1213-1239`), walks the base-script chain via a bare `Ref<T>::is_valid()` null-pointer check with **no cycle detection**. `KotlinScript._getBaseScript()` was forced to always return a real, non-null sentinel — including when called on that sentinel itself — so the loop never terminates and eventually crashes the editor. Confirmed via lldb against a self-built Godot 4.7.1 dev binary that the returned object itself is not corrupted: this is purely an inability-to-express-null bug, not a memory-safety bug.

Scanning `godot-version/v4_7_1/extension_api.json`: **43 virtual methods across 30 classes** return an engine-class type, all sharing this same gap — several documented in Godot's own C++ headers as legitimately nullable (`AudioEffect._instantiate`, `Control._make_custom_tooltip`, `EditorPlugin._get_plugin_icon`, `Mesh._surface_get_material`, `PhysicsServer2D/3DExtension._space_get_direct_state`/`_body_get_direct_state`, `Texture2D._get_image`, `VideoStreamPlayback._get_texture`, `ScriptLanguageExtension._create_script`).

Closes #143.

## The fix

- `NativeMethodGenerator.buildMethod` gains a `forceNullableEngineReturn: Boolean = false` parameter (default `false`, so every other call site — builtin constructors, static methods, utility functions, non-virtual instance methods — is byte-for-byte unaffected) that makes `returnTypeSpec` nullable (`.copy(nullable = true)`) when the resolved return type is an engine class or singleton and the flag is set.
- `NativeEngineClassGenerator.kt`'s standalone-instance-method `buildMethod(...)` call site (the same one that already passes `forceNullableEngineArgs = method.isVirtual`) now also passes `forceNullableEngineReturn = method.isVirtual`. The static-methods call site is untouched (static methods are never virtual).
- `VirtualCallImplGen.buildReturnWrite`'s `ctx.isEngineClass(returnType)` branch now writes `result?.rawPtr` instead of `result.rawPtr` — writing a null pointer into the (nullable) `COpaquePointerVar.value` when `result` is null, mirroring how `appendArgRead`'s sibling engine-class branch already null-safes the read side (`?.let { }`).
- Applied unconditionally to all 43 affected virtuals, matching how #141/#142 applied unconditionally to arguments regardless of any JSON metadata — not special-cased to `_get_base_script`, and not conditioned on `is_required` (`extension_api.json`'s `is_required: true` on `_get_base_script` means the virtual itself must be implemented, not that its return value can't be null).
- Updated the Return row + added an explanatory subsection to `docs/technical-design/virtual-dispatch.md`.
- Design note: `docs/notes/issue-143-virtual-dispatch-nullable-returns-plan.md` (scope + outcome), following #135/#137/#139/#141's convention.
- No test added: matching precedent from #135/#137/#139/#141, none of which added a unit test for `VirtualCallImplGen`/`NativeMethodGenerator` — there is no existing test scaffolding for either, and building it from scratch would be disproportionate to this fix alone.

## Verification

- `:kotlin-native:api:generated:generateGodotKotlinNativeApi` — regenerated; confirmed by reading the generated output directly:
  - `ScriptExtension.kt`'s `_getBaseScript()`: return type is now `Script?` (the `TODO()` stub body is unchanged — only the declared type changed).
  - `ScriptExtensionVirtualCalls.kt`'s `getBaseScript` trampoline: `ret?.reinterpret<COpaquePointerVar>()?.pointed?.value = result?.rawPtr`, null-safe on the engine-class return.
  - Spot-checked `Texture2D._get_image` (`Image?`, `result?.rawPtr`) and `Mesh._surface_get_material` (`Material?`, same trampoline shape) from the issue's list — same nullable-return + null-safe-write pattern.
  - Confirmed no remaining unguarded `result.rawPtr` write against a `COpaquePointerVar` anywhere in the regenerated output (`grep`'d for the pattern across `kotlin-native/api/generated/build/generated/`) — every engine-class-returning virtual now writes `result?.rawPtr`. Non-engine-class branches (`Variant.newCopyRaw`, heap-backed builtins via `allocConstTypePtrArray`) are correctly untouched and still write `result.rawPtr` unconditionally, since those return types weren't made nullable by this fix.
- `./gradlew assemble` — `BUILD SUCCESSFUL` (grepped directly from the log for `BUILD SUCCESSFUL`/`BUILD FAILED`, exit code checked, no exit-code-masking pipe). Ran with `--max-workers=2` given this repo's known heap-pressure issue on concurrent native-linking tasks.
- `./gradlew spotlessApply` — `BUILD SUCCESSFUL`; as the known repo quirk, it also pulled in an unrelated reformat of `processor/src/main/kotlin/io/github/kingg22/kogot/processor/KogotProcessor.kt`, reverted with `git checkout --` to keep the diff scoped to this fix.
- Checked no other `main`-reachable code overrides a now-affected virtual with a non-nullable return signature: `grep -rln "override fun _" --include="*.kt" .` (excluding `build/` and other worktree paths) only turns up `mi-juego-prueba/kotlin_native_game/`'s `Sprite.kt`/`TestOne.kt`/`SpriteBench.kt`, overriding `_ready()` (no return) and `_process(delta: Double)` (returns `Unit`) — neither affected, and `./gradlew assemble` (which builds `mi-juego-prueba`) already confirmed these compile cleanly.

### What is NOT verified

Actual runtime behavior in the Godot editor is NOT verified here — only that generated code compiles with the intended nullable shape. issue #42/PR #134 will verify the actual `_get_base_script` infinite-loop fix end-to-end after rebasing onto this.

## Note for #42

Leaving this PR to be merged by the repo owner, same as #138/#140/#142. `feat/kotlin-script-language` (#42/PR #134, branch `claude/issue-42-14aff6`, a separate worktree not touched here) needs to rebase onto this afterward and update `KotlinScript.kt`'s `_getBaseScript()` override to return `Script?` (returning real `null` instead of a shared self-referential sentinel) once this lands — same as #142 left its 10 affected overrides for #42's branch to update.

## Resumen de Sourcery

Hacer que los retornos del despacho virtual de las clases del motor admitan valores nulos para que las sobrescrituras de Kotlin puedan informar correctamente sobre objetos de Godot ausentes.

Correcciones de errores:
- Permitir que los métodos virtuales de las clases del motor y los singleton devuelvan `null` de forma segura mediante la generación de tipos de retorno anulables y escrituras de punteros nativos seguras frente a valores nulos.
- Evitar que el despacho virtual fuerce objetos centinela no nulos, solucionando los bloqueos causados por cadenas no terminantes de referencias a objetos de Godot, como los scripts base de `ScriptExtension`.

Mejoras:
- Aplicar de forma coherente el manejo de retornos anulables en todos los métodos virtuales afectados de las clases del motor y documentar el comportamiento del despacho virtual.

Documentación:
- Documentar los retornos anulables de clases del motor y singleton en la documentación de diseño del despacho virtual y añadir una nota de diseño específica para este problema.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make engine-class virtual dispatch returns nullable so Kotlin overrides can correctly report absent Godot objects.

Bug Fixes:
- Allow engine-class and singleton virtual methods to return null safely by generating nullable return types and null-safe native pointer writes.
- Prevent virtual dispatch from forcing non-null sentinel objects, addressing crashes caused by non-terminating Godot object-reference chains such as ScriptExtension base scripts.

Enhancements:
- Apply nullable return handling consistently across all affected engine-class virtual methods and document the virtual-dispatch behavior.

Documentation:
- Document nullable engine-class and singleton returns in the virtual dispatch design documentation and add an issue-specific design note.

</details>